### PR TITLE
refactor: ToolProvider ABC — dynamic list_tools/call_tool interface (#15)

### DIFF
--- a/dev-suite/src/tools/__init__.py
+++ b/dev-suite/src/tools/__init__.py
@@ -1,8 +1,7 @@
 """MCP and external tool integrations.
 
-The ToolProvider pattern ("front desk") lets agents interact with
-filesystem and GitHub through a stable interface. The backend is
-swappable without changing agent code:
+The ToolProvider pattern exposes tools dynamically via list_tools()
+and call_tool(). The backend is swappable without changing agent code:
 
 - Phase 1: LocalToolProvider (Python/pathlib/httpx)
 - Phase 2: MCPToolProvider (real MCP subprocess spawning, issue #13)
@@ -12,14 +11,22 @@ Usage:
 
     config = load_mcp_config("mcp-config.json")
     provider = LocalToolProvider(workspace_root="./my-project")
-    tools = get_tools(provider)
+    tools = get_tools(provider)  # auto-generates LangChain Tools from list_tools()
 """
 
 from .mcp_bridge import MCPConfig, MCPConfigError, get_tools, load_mcp_config
-from .provider import LocalToolProvider, PathValidationError, ToolProvider
+from .provider import (
+    LocalToolProvider,
+    PathValidationError,
+    ToolDefinition,
+    ToolNotFoundError,
+    ToolProvider,
+)
 
 __all__ = [
     "ToolProvider",
+    "ToolDefinition",
+    "ToolNotFoundError",
     "LocalToolProvider",
     "PathValidationError",
     "MCPConfig",

--- a/dev-suite/src/tools/mcp_bridge.py
+++ b/dev-suite/src/tools/mcp_bridge.py
@@ -98,9 +98,9 @@ def load_mcp_config(config_path: str | Path) -> MCPConfig:
 def get_tools(provider: ToolProvider) -> list[Tool]:
     """Create LangChain Tool objects from a ToolProvider.
 
-    This is the main entry point for the orchestrator.
-    Call this with any ToolProvider implementation and get back
-    a list of Tools ready to bind to LangGraph agents.
+    Dynamically generates Tools from the provider's list_tools() response.
+    Each generated Tool wraps provider.call_tool() with JSON input parsing
+    for multi-argument tools and string passthrough for single-argument tools.
 
     Args:
         provider: Any ToolProvider (LocalToolProvider, MCPToolProvider, etc.)
@@ -108,85 +108,69 @@ def get_tools(provider: ToolProvider) -> list[Tool]:
     Returns:
         List of LangChain Tool objects the agents can use.
     """
-    return [
-        Tool(
-            name="filesystem_read",
-            description=(
-                "Read a file from the project workspace. "
-                "Input: relative file path (e.g., 'src/main.py'). "
-                "Output: file contents as text."
-            ),
-            func=provider.filesystem_read,
-        ),
-        Tool(
-            name="filesystem_write",
-            description=(
-                "Write content to a file in the project workspace. "
-                "Input: JSON string with 'path' and 'content' keys. "
-                "Output: confirmation message."
-            ),
-            func=lambda input_str, p=provider: _parse_write_call(p, input_str),
-        ),
-        Tool(
-            name="filesystem_list",
-            description=(
-                "List files and directories in the project workspace. "
-                "Input: relative directory path (e.g., 'src/' or '.'). "
-                "Output: formatted directory listing."
-            ),
-            func=provider.filesystem_list,
-        ),
-        Tool(
-            name="github_create_pr",
-            description=(
-                "Create a GitHub pull request. "
-                "Input: JSON string with 'title', 'body', 'head_branch', "
-                "and optional 'base_branch' keys. "
-                "Output: PR URL."
-            ),
-            func=lambda input_str, p=provider: _parse_create_pr_call(p, input_str),
-        ),
-        Tool(
-            name="github_read_diff",
-            description=(
-                "Read the diff of a GitHub pull request. "
-                "Input: PR number as a string (e.g., '42'). "
-                "Output: diff text."
-            ),
-            func=lambda input_str, p=provider: p.github_read_diff(int(input_str.strip())),
-        ),
-    ]
+    tools = []
+    for defn in provider.list_tools():
+        properties = defn.parameters.get("properties", {})
+        required = defn.parameters.get("required", [])
+
+        # Determine if this is a single-arg tool (one required string param)
+        # or a multi-arg tool (needs JSON parsing)
+        single_arg_key = None
+        if len(required) == 1 and len(properties) == 1:
+            key = required[0]
+            if properties[key].get("type") == "string":
+                single_arg_key = key
+
+        if single_arg_key:
+            # Single string argument — pass the raw input string directly
+            tool = Tool(
+                name=defn.name,
+                description=defn.description,
+                func=_make_single_arg_handler(provider, defn.name, single_arg_key),
+            )
+        else:
+            # Multi-argument — expect JSON input and parse it
+            tool = Tool(
+                name=defn.name,
+                description=_build_json_description(defn),
+                func=_make_multi_arg_handler(provider, defn.name),
+            )
+
+        tools.append(tool)
+
+    return tools
 
 
-def _parse_write_call(provider: ToolProvider, input_str: str) -> str:
-    """Parse JSON input for filesystem_write and call the provider."""
-    try:
-        data = json.loads(input_str)
-    except json.JSONDecodeError:
-        return "Error: Input must be a JSON string with 'path' and 'content' keys."
-
-    path = data.get("path")
-    content = data.get("content")
-
-    if not path or content is None:
-        return "Error: JSON must include 'path' and 'content' keys."
-
-    return provider.filesystem_write(path, content)
+def _make_single_arg_handler(provider: ToolProvider, tool_name: str, arg_key: str):
+    """Create a handler for a single-string-argument tool."""
+    def handler(input_str: str) -> str:
+        return provider.call_tool(tool_name, {arg_key: input_str.strip()})
+    return handler
 
 
-def _parse_create_pr_call(provider: ToolProvider, input_str: str) -> str:
-    """Parse JSON input for github_create_pr and call the provider."""
-    try:
-        data = json.loads(input_str)
-    except json.JSONDecodeError:
-        return "Error: Input must be a JSON string with 'title', 'body', and 'head_branch' keys."
+def _make_multi_arg_handler(provider: ToolProvider, tool_name: str):
+    """Create a handler that parses JSON input for a multi-argument tool."""
+    def handler(input_str: str) -> str:
+        try:
+            arguments = json.loads(input_str)
+        except json.JSONDecodeError:
+            return f"Error: Input for '{tool_name}' must be a valid JSON string."
 
-    title = data.get("title")
-    body = data.get("body", "")
-    head_branch = data.get("head_branch")
-    base_branch = data.get("base_branch", "main")
+        if not isinstance(arguments, dict):
+            return f"Error: Input for '{tool_name}' must be a JSON object."
 
-    if not title or not head_branch:
-        return "Error: JSON must include 'title' and 'head_branch' keys."
+        return provider.call_tool(tool_name, arguments)
+    return handler
 
-    return provider.github_create_pr(title, body, head_branch, base_branch)
+
+def _build_json_description(defn) -> str:
+    """Append JSON input hint to a multi-arg tool's description."""
+    required = defn.parameters.get("required", [])
+    properties = defn.parameters.get("properties", {})
+    optional = [k for k in properties if k not in required]
+
+    parts = [defn.description, f"Input: JSON string with {', '.join(repr(k) for k in required)} keys."]
+    if optional:
+        parts.append(f"Optional: {', '.join(repr(k) for k in optional)}.")
+
+    return " ".join(parts)

--- a/dev-suite/src/tools/provider.py
+++ b/dev-suite/src/tools/provider.py
@@ -1,7 +1,7 @@
 """ToolProvider ABC and implementations.
 
-Defines the interface ("front desk") that agents interact with for
-filesystem and GitHub operations. The backend is swappable:
+Defines the dynamic tool discovery interface that agents interact with
+for external operations. The backend is swappable:
 
 - Phase 1: LocalToolProvider (Python/pathlib/httpx)
 - Phase 2: MCPToolProvider (real MCP server subprocess spawning, issue #13)
@@ -9,6 +9,11 @@ filesystem and GitHub operations. The backend is swappable:
 Agents and the orchestrator never import the concrete provider directly —
 they call get_tools() from mcp_bridge.py, which returns LangChain Tools
 backed by whichever provider is configured.
+
+Interface design:
+    - list_tools() → dynamic discovery (supports any number of tools)
+    - call_tool(name, arguments) → unified dispatch (name-based routing)
+    - ToolDefinition → Pydantic model describing each tool's schema
 """
 
 import os
@@ -16,40 +21,71 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 
 import httpx
+from pydantic import BaseModel, Field
+
+
+# ── Tool Definition Schema ──
+
+
+class ToolDefinition(BaseModel):
+    """Schema describing a single tool's interface.
+
+    Mirrors the MCP tools/list response format so MCPToolProvider
+    can pass MCP inputSchema through without transformation.
+
+    Attributes:
+        name: Unique tool identifier (e.g., "filesystem_read").
+        description: Human-readable description for the LLM.
+        parameters: JSON Schema dict describing expected arguments.
+    """
+    name: str
+    description: str
+    parameters: dict = Field(default_factory=dict)
+
+
+# ── Exceptions ──
 
 
 class PathValidationError(Exception):
     """Raised when a filesystem path escapes the allowed workspace root."""
 
 
+class ToolNotFoundError(Exception):
+    """Raised when call_tool is invoked with an unknown tool name."""
+
+
+# ── Abstract Base Class ──
+
+
 class ToolProvider(ABC):
     """Abstract interface for tool operations.
 
-    Defines the 5 methods agents can call. Any concrete provider
-    (local Python, MCP subprocess, mock) must implement all of them.
+    Providers expose their capabilities dynamically via list_tools()
+    and accept invocations via call_tool(). This enables any number
+    of tools without requiring ABC method changes.
     """
 
     @abstractmethod
-    def filesystem_read(self, path: str) -> str:
-        """Read a file and return its contents as text."""
+    def list_tools(self) -> list[ToolDefinition]:
+        """Return all tools this provider offers."""
 
     @abstractmethod
-    def filesystem_write(self, path: str, content: str) -> str:
-        """Write content to a file. Returns confirmation message."""
+    def call_tool(self, name: str, arguments: dict) -> str:
+        """Call a tool by name with the given arguments.
 
-    @abstractmethod
-    def filesystem_list(self, path: str) -> str:
-        """List files and directories at the given path. Returns formatted listing."""
+        Args:
+            name: Tool name as returned by list_tools().
+            arguments: Dict of arguments matching the tool's parameter schema.
 
-    @abstractmethod
-    def github_create_pr(
-        self, title: str, body: str, head_branch: str, base_branch: str = "main"
-    ) -> str:
-        """Create a GitHub pull request. Returns PR URL."""
+        Returns:
+            Tool execution result as a string.
 
-    @abstractmethod
-    def github_read_diff(self, pr_number: int) -> str:
-        """Read the diff of a GitHub pull request. Returns diff text."""
+        Raises:
+            ToolNotFoundError: If the tool name is not recognized.
+        """
+
+
+# ── Path Validation ──
 
 
 def _validate_path(requested: str, workspace_root: Path) -> Path:
@@ -69,11 +105,18 @@ def _validate_path(requested: str, workspace_root: Path) -> Path:
     return resolved
 
 
+# ── Local Tool Provider ──
+
+
 class LocalToolProvider(ToolProvider):
     """Python-native tool provider for Phase 1.
 
     Filesystem operations use pathlib (with path validation).
     GitHub operations use httpx against the GitHub REST API.
+
+    Tools are registered in _TOOL_REGISTRY, which maps tool names to
+    their definitions and handler methods. list_tools() and call_tool()
+    are driven by this registry.
     """
 
     def __init__(
@@ -91,7 +134,135 @@ class LocalToolProvider(ToolProvider):
         if not self.workspace_root.is_dir():
             raise ValueError(f"Workspace root does not exist: {self.workspace_root}")
 
-    def filesystem_read(self, path: str) -> str:
+        # Registry: maps tool name → (ToolDefinition, handler_method)
+        self._tool_registry: dict[str, tuple[ToolDefinition, callable]] = {
+            "filesystem_read": (
+                ToolDefinition(
+                    name="filesystem_read",
+                    description=(
+                        "Read a file from the project workspace. "
+                        "Input: relative file path (e.g., 'src/main.py'). "
+                        "Output: file contents as text."
+                    ),
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "path": {"type": "string", "description": "Relative file path to read"},
+                        },
+                        "required": ["path"],
+                    },
+                ),
+                self._filesystem_read,
+            ),
+            "filesystem_write": (
+                ToolDefinition(
+                    name="filesystem_write",
+                    description=(
+                        "Write content to a file in the project workspace. "
+                        "Output: confirmation message."
+                    ),
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "path": {"type": "string", "description": "Relative file path to write"},
+                            "content": {"type": "string", "description": "File content to write"},
+                        },
+                        "required": ["path", "content"],
+                    },
+                ),
+                self._filesystem_write,
+            ),
+            "filesystem_list": (
+                ToolDefinition(
+                    name="filesystem_list",
+                    description=(
+                        "List files and directories in the project workspace. "
+                        "Input: relative directory path (e.g., 'src/' or '.'). "
+                        "Output: formatted directory listing."
+                    ),
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "path": {"type": "string", "description": "Relative directory path to list"},
+                        },
+                        "required": ["path"],
+                    },
+                ),
+                self._filesystem_list,
+            ),
+            "github_create_pr": (
+                ToolDefinition(
+                    name="github_create_pr",
+                    description=(
+                        "Create a GitHub pull request. "
+                        "Output: PR URL."
+                    ),
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "title": {"type": "string", "description": "PR title"},
+                            "body": {"type": "string", "description": "PR description"},
+                            "head_branch": {"type": "string", "description": "Source branch"},
+                            "base_branch": {"type": "string", "description": "Target branch", "default": "main"},
+                        },
+                        "required": ["title", "head_branch"],
+                    },
+                ),
+                self._github_create_pr,
+            ),
+            "github_read_diff": (
+                ToolDefinition(
+                    name="github_read_diff",
+                    description=(
+                        "Read the diff of a GitHub pull request. "
+                        "Input: PR number. Output: diff text."
+                    ),
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "pr_number": {"type": "integer", "description": "Pull request number"},
+                        },
+                        "required": ["pr_number"],
+                    },
+                ),
+                self._github_read_diff,
+            ),
+        }
+
+    # ── ToolProvider interface ──
+
+    def list_tools(self) -> list[ToolDefinition]:
+        """Return all tools this provider offers."""
+        return [defn for defn, _ in self._tool_registry.values()]
+
+    def call_tool(self, name: str, arguments: dict) -> str:
+        """Call a tool by name with the given arguments.
+
+        Validates that required arguments are present before dispatching.
+        Extra arguments are ignored (Postel's Law).
+        """
+        if name not in self._tool_registry:
+            available = ", ".join(sorted(self._tool_registry.keys()))
+            raise ToolNotFoundError(
+                f"Unknown tool '{name}'. Available tools: {available}"
+            )
+
+        definition, handler = self._tool_registry[name]
+
+        # Validate required arguments
+        required = definition.parameters.get("required", [])
+        missing = [key for key in required if key not in arguments]
+        if missing:
+            raise ValueError(
+                f"Tool '{name}' missing required arguments: {', '.join(missing)}"
+            )
+
+        return handler(**{k: v for k, v in arguments.items()
+                         if k in definition.parameters.get("properties", {})})
+
+    # ── Filesystem operations (private handlers) ──
+
+    def _filesystem_read(self, path: str) -> str:
         """Read a file within the workspace."""
         validated = _validate_path(path, self.workspace_root)
 
@@ -100,7 +271,7 @@ class LocalToolProvider(ToolProvider):
 
         return validated.read_text(encoding="utf-8")
 
-    def filesystem_write(self, path: str, content: str) -> str:
+    def _filesystem_write(self, path: str, content: str) -> str:
         """Write content to a file within the workspace."""
         validated = _validate_path(path, self.workspace_root)
 
@@ -109,7 +280,7 @@ class LocalToolProvider(ToolProvider):
 
         return f"Successfully wrote {len(content)} characters to {path}"
 
-    def filesystem_list(self, path: str) -> str:
+    def _filesystem_list(self, path: str) -> str:
         """List contents of a directory within the workspace."""
         validated = _validate_path(path, self.workspace_root)
 
@@ -128,6 +299,8 @@ class LocalToolProvider(ToolProvider):
 
         return "\n".join(lines)
 
+    # ── GitHub operations (private handlers) ──
+
     def _github_headers(self) -> dict:
         """Build GitHub API request headers."""
         return {
@@ -140,8 +313,8 @@ class LocalToolProvider(ToolProvider):
         """Build a GitHub API URL for the configured repo."""
         return f"https://api.github.com/repos/{self.github_owner}/{self.github_repo}{endpoint}"
 
-    def github_create_pr(
-        self, title: str, body: str, head_branch: str, base_branch: str = "main"
+    def _github_create_pr(
+        self, title: str, head_branch: str, body: str = "", base_branch: str = "main",
     ) -> str:
         """Create a pull request via the GitHub REST API."""
         if not self.github_token:
@@ -167,7 +340,7 @@ class LocalToolProvider(ToolProvider):
             f"GitHub API error {response.status_code}: {response.text}"
         )
 
-    def github_read_diff(self, pr_number: int) -> str:
+    def _github_read_diff(self, pr_number: int) -> str:
         """Read the diff of a pull request via the GitHub REST API."""
         if not self.github_token:
             raise ValueError("GITHUB_TOKEN is required for GitHub operations")

--- a/dev-suite/tests/test_mcp_tools.py
+++ b/dev-suite/tests/test_mcp_tools.py
@@ -1,14 +1,18 @@
-"""Tests for Step 5: MCP integration — ToolProvider pattern.
+"""Tests for MCP integration — ToolProvider pattern.
 
 Unit tests cover:
-- ToolProvider ABC contract
-- LocalToolProvider filesystem operations
+- ToolProvider ABC contract (list_tools + call_tool)
+- ToolDefinition Pydantic model
+- call_tool dispatch, validation, and error handling
+- LocalToolProvider filesystem operations (private handlers)
+- LocalToolProvider GitHub operations (mocked, private handlers)
 - Path validation (directory traversal prevention)
 - MCP config loading and version validation
-- LangChain tool wrapping via get_tools()
+- Dynamic LangChain tool wrapping via get_tools()
 
 Integration tests cover:
 - Real filesystem operations in a temp directory
+- Full round-trip via call_tool interface
 """
 
 import json
@@ -21,17 +25,50 @@ import pytest
 from src.tools.mcp_bridge import (
     MCPConfig,
     MCPConfigError,
-    _parse_create_pr_call,
-    _parse_write_call,
     get_tools,
     load_mcp_config,
 )
 from src.tools.provider import (
     LocalToolProvider,
     PathValidationError,
+    ToolDefinition,
+    ToolNotFoundError,
     ToolProvider,
     _validate_path,
 )
+
+
+# ============================================================
+# ToolDefinition model
+# ============================================================
+
+
+class TestToolDefinition:
+    """Verify ToolDefinition Pydantic model."""
+
+    def test_basic_creation(self):
+        defn = ToolDefinition(
+            name="test_tool",
+            description="A test tool",
+            parameters={"type": "object", "properties": {"x": {"type": "string"}}},
+        )
+        assert defn.name == "test_tool"
+        assert defn.description == "A test tool"
+        assert "properties" in defn.parameters
+
+    def test_default_empty_parameters(self):
+        defn = ToolDefinition(name="simple", description="No params")
+        assert defn.parameters == {}
+
+    def test_serialization_round_trip(self):
+        defn = ToolDefinition(
+            name="roundtrip",
+            description="Test",
+            parameters={"type": "object", "required": ["a"]},
+        )
+        data = defn.model_dump()
+        restored = ToolDefinition(**data)
+        assert restored == defn
 
 
 # ============================================================
@@ -47,9 +84,42 @@ class TestToolProviderABC:
         with pytest.raises(TypeError):
             ToolProvider()
 
-    def test_abc_defines_five_methods(self):
-        """The ABC defines exactly the 5 expected abstract methods."""
+    def test_abc_defines_two_methods(self):
+        """The ABC defines exactly the 2 expected abstract methods."""
         abstract_methods = ToolProvider.__abstractmethods__
+        expected = {"list_tools", "call_tool"}
+        assert abstract_methods == expected
+
+    def test_local_provider_is_valid_implementation(self, tmp_path):
+        """LocalToolProvider satisfies the ABC contract."""
+        provider = LocalToolProvider(workspace_root=tmp_path)
+        assert isinstance(provider, ToolProvider)
+
+
+# ============================================================
+# LocalToolProvider — list_tools
+# ============================================================
+
+
+class TestListTools:
+    """Test dynamic tool discovery via list_tools()."""
+
+    @pytest.fixture
+    def provider(self, tmp_path):
+        return LocalToolProvider(workspace_root=tmp_path)
+
+    def test_returns_five_tools(self, provider):
+        tools = provider.list_tools()
+        assert len(tools) == 5
+
+    def test_returns_tool_definitions(self, provider):
+        tools = provider.list_tools()
+        for tool in tools:
+            assert isinstance(tool, ToolDefinition)
+
+    def test_tool_names(self, provider):
+        tools = provider.list_tools()
+        names = {t.name for t in tools}
         expected = {
             "filesystem_read",
             "filesystem_write",
@@ -57,12 +127,108 @@ class TestToolProviderABC:
             "github_create_pr",
             "github_read_diff",
         }
-        assert abstract_methods == expected
+        assert names == expected
 
-    def test_local_provider_is_valid_implementation(self, tmp_path):
-        """LocalToolProvider satisfies the ABC contract."""
-        provider = LocalToolProvider(workspace_root=tmp_path)
-        assert isinstance(provider, ToolProvider)
+    def test_all_tools_have_descriptions(self, provider):
+        for tool in provider.list_tools():
+            assert tool.description, f"Tool '{tool.name}' has no description"
+            assert len(tool.description) > 10, f"Tool '{tool.name}' description too short"
+
+    def test_all_tools_have_parameter_schemas(self, provider):
+        for tool in provider.list_tools():
+            assert "type" in tool.parameters, f"Tool '{tool.name}' has no parameter schema"
+            assert tool.parameters["type"] == "object"
+
+    def test_all_tools_have_required_fields(self, provider):
+        for tool in provider.list_tools():
+            assert "required" in tool.parameters, f"Tool '{tool.name}' has no required fields"
+
+
+# ============================================================
+# LocalToolProvider — call_tool dispatch
+# ============================================================
+
+
+class TestCallTool:
+    """Test call_tool dispatch, validation, and error handling."""
+
+    @pytest.fixture
+    def workspace(self, tmp_path):
+        (tmp_path / "test.txt").write_text("test content", encoding="utf-8")
+        (tmp_path / "src").mkdir()
+        return tmp_path
+
+    @pytest.fixture
+    def provider(self, workspace):
+        return LocalToolProvider(workspace_root=workspace)
+
+    def test_dispatch_filesystem_read(self, provider):
+        result = provider.call_tool("filesystem_read", {"path": "test.txt"})
+        assert result == "test content"
+
+    def test_dispatch_filesystem_write(self, provider, workspace):
+        result = provider.call_tool("filesystem_write", {"path": "new.txt", "content": "hello"})
+        assert "Successfully wrote" in result
+        assert (workspace / "new.txt").read_text() == "hello"
+
+    def test_dispatch_filesystem_list(self, provider):
+        result = provider.call_tool("filesystem_list", {"path": "."})
+        assert "test.txt" in result
+
+    def test_unknown_tool_raises_error(self, provider):
+        with pytest.raises(ToolNotFoundError, match="Unknown tool 'nonexistent'"):
+            provider.call_tool("nonexistent", {})
+
+    def test_unknown_tool_lists_available(self, provider):
+        with pytest.raises(ToolNotFoundError, match="filesystem_read"):
+            provider.call_tool("bad_name", {})
+
+    def test_missing_required_argument(self, provider):
+        with pytest.raises(ValueError, match="missing required arguments"):
+            provider.call_tool("filesystem_read", {})
+
+    def test_missing_multiple_required_arguments(self, provider):
+        with pytest.raises(ValueError, match="path.*content|content.*path"):
+            provider.call_tool("filesystem_write", {})
+
+    def test_extra_arguments_ignored(self, provider):
+        """Postel's Law — extra arguments don't cause errors."""
+        result = provider.call_tool("filesystem_read", {"path": "test.txt", "extra_field": "ignored"})
+        assert result == "test content"
+
+    @patch("src.tools.provider.httpx.post")
+    def test_dispatch_github_create_pr(self, mock_post, tmp_path):
+        mock_post.return_value = MagicMock(
+            status_code=201,
+            json=lambda: {"number": 99, "html_url": "https://github.com/test/pr/99"},
+        )
+        provider = LocalToolProvider(
+            workspace_root=tmp_path,
+            github_token="tok",
+            github_owner="owner",
+            github_repo="repo",
+        )
+        result = provider.call_tool("github_create_pr", {
+            "title": "Test PR",
+            "body": "Description",
+            "head_branch": "feature/test",
+        })
+        assert "PR #99" in result
+
+    @patch("src.tools.provider.httpx.get")
+    def test_dispatch_github_read_diff(self, mock_get, tmp_path):
+        mock_get.return_value = MagicMock(
+            status_code=200,
+            text="diff --git a/file.py b/file.py",
+        )
+        provider = LocalToolProvider(
+            workspace_root=tmp_path,
+            github_token="tok",
+            github_owner="owner",
+            github_repo="repo",
+        )
+        result = provider.call_tool("github_read_diff", {"pr_number": 42})
+        assert "diff --git" in result
 
 
 # ============================================================
@@ -74,35 +240,29 @@ class TestPathValidation:
     """Verify path validation prevents directory traversal."""
 
     def test_valid_relative_path(self, tmp_path):
-        """A simple relative path within workspace passes validation."""
         (tmp_path / "file.txt").touch()
         result = _validate_path("file.txt", tmp_path)
         assert result == (tmp_path / "file.txt").resolve()
 
     def test_valid_nested_path(self, tmp_path):
-        """A nested path within workspace passes validation."""
         (tmp_path / "src").mkdir()
         (tmp_path / "src" / "main.py").touch()
         result = _validate_path("src/main.py", tmp_path)
         assert result == (tmp_path / "src" / "main.py").resolve()
 
     def test_traversal_with_dotdot_rejected(self, tmp_path):
-        """A path with .. that escapes the workspace is rejected."""
         with pytest.raises(PathValidationError, match="outside workspace root"):
             _validate_path("../../../etc/passwd", tmp_path)
 
     def test_traversal_with_absolute_path_rejected(self, tmp_path):
-        """An absolute path outside the workspace is rejected."""
         with pytest.raises(PathValidationError, match="outside workspace root"):
             _validate_path("/etc/passwd", tmp_path)
 
     def test_traversal_hidden_in_middle(self, tmp_path):
-        """A path that goes up and back down is rejected if it leaves workspace."""
         with pytest.raises(PathValidationError, match="outside workspace root"):
             _validate_path("src/../../etc/passwd", tmp_path)
 
     def test_path_within_workspace_after_dotdot_allowed(self, tmp_path):
-        """A path with .. that stays within workspace is allowed."""
         (tmp_path / "src").mkdir()
         (tmp_path / "file.txt").touch()
         result = _validate_path("src/../file.txt", tmp_path)
@@ -110,7 +270,7 @@ class TestPathValidation:
 
 
 # ============================================================
-# LocalToolProvider — filesystem operations
+# LocalToolProvider — filesystem operations (private handlers)
 # ============================================================
 
 
@@ -119,7 +279,6 @@ class TestLocalToolProviderFilesystem:
 
     @pytest.fixture
     def workspace(self, tmp_path):
-        """Create a workspace with sample files."""
         (tmp_path / "hello.txt").write_text("Hello, world!", encoding="utf-8")
         (tmp_path / "src").mkdir()
         (tmp_path / "src" / "main.py").write_text("print('hi')", encoding="utf-8")
@@ -130,51 +289,51 @@ class TestLocalToolProviderFilesystem:
         return LocalToolProvider(workspace_root=workspace)
 
     def test_read_existing_file(self, provider):
-        result = provider.filesystem_read("hello.txt")
+        result = provider._filesystem_read("hello.txt")
         assert result == "Hello, world!"
 
     def test_read_nested_file(self, provider):
-        result = provider.filesystem_read("src/main.py")
+        result = provider._filesystem_read("src/main.py")
         assert result == "print('hi')"
 
     def test_read_nonexistent_file(self, provider):
         with pytest.raises(FileNotFoundError):
-            provider.filesystem_read("does_not_exist.txt")
+            provider._filesystem_read("does_not_exist.txt")
 
     def test_read_path_traversal_blocked(self, provider):
         with pytest.raises(PathValidationError):
-            provider.filesystem_read("../../etc/passwd")
+            provider._filesystem_read("../../etc/passwd")
 
     def test_write_new_file(self, provider, workspace):
-        result = provider.filesystem_write("new_file.txt", "new content")
+        result = provider._filesystem_write("new_file.txt", "new content")
         assert "Successfully wrote" in result
         assert (workspace / "new_file.txt").read_text() == "new content"
 
     def test_write_creates_directories(self, provider, workspace):
-        result = provider.filesystem_write("deep/nested/file.txt", "deep content")
+        result = provider._filesystem_write("deep/nested/file.txt", "deep content")
         assert "Successfully wrote" in result
         assert (workspace / "deep" / "nested" / "file.txt").read_text() == "deep content"
 
     def test_write_path_traversal_blocked(self, provider):
         with pytest.raises(PathValidationError):
-            provider.filesystem_write("../../etc/evil", "bad")
+            provider._filesystem_write("../../etc/evil", "bad")
 
     def test_list_directory(self, provider):
-        result = provider.filesystem_list(".")
+        result = provider._filesystem_list(".")
         assert "[FILE] hello.txt" in result
         assert "[DIR]  src" in result
 
     def test_list_subdirectory(self, provider):
-        result = provider.filesystem_list("src")
+        result = provider._filesystem_list("src")
         assert "[FILE] src/main.py" in result
 
     def test_list_nonexistent_directory(self, provider):
         with pytest.raises(NotADirectoryError):
-            provider.filesystem_list("nonexistent")
+            provider._filesystem_list("nonexistent")
 
     def test_list_path_traversal_blocked(self, provider):
         with pytest.raises(PathValidationError):
-            provider.filesystem_list("../../")
+            provider._filesystem_list("../../")
 
     def test_invalid_workspace_root(self):
         with pytest.raises(ValueError, match="does not exist"):
@@ -182,7 +341,7 @@ class TestLocalToolProviderFilesystem:
 
 
 # ============================================================
-# LocalToolProvider — GitHub operations (mocked)
+# LocalToolProvider — GitHub operations (mocked, private handlers)
 # ============================================================
 
 
@@ -205,7 +364,7 @@ class TestLocalToolProviderGitHub:
             json=lambda: {"number": 42, "html_url": "https://github.com/test/pr/42"},
         )
 
-        result = provider.github_create_pr(
+        result = provider._github_create_pr(
             title="Test PR",
             body="Description",
             head_branch="feature/test",
@@ -223,7 +382,7 @@ class TestLocalToolProviderGitHub:
         )
 
         with pytest.raises(RuntimeError, match="GitHub API error 422"):
-            provider.github_create_pr("PR", "body", "branch")
+            provider._github_create_pr(title="PR", body="body", head_branch="branch")
 
     def test_create_pr_no_token(self, tmp_path):
         provider = LocalToolProvider(
@@ -231,7 +390,7 @@ class TestLocalToolProviderGitHub:
             github_token="",
         )
         with pytest.raises(ValueError, match="GITHUB_TOKEN"):
-            provider.github_create_pr("PR", "body", "branch")
+            provider._github_create_pr(title="PR", body="body", head_branch="branch")
 
     @patch("src.tools.provider.httpx.get")
     def test_read_diff_success(self, mock_get, provider):
@@ -240,7 +399,7 @@ class TestLocalToolProviderGitHub:
             text="diff --git a/file.py b/file.py\n+new line",
         )
 
-        result = provider.github_read_diff(42)
+        result = provider._github_read_diff(42)
         assert "diff --git" in result
 
     @patch("src.tools.provider.httpx.get")
@@ -251,7 +410,7 @@ class TestLocalToolProviderGitHub:
         )
 
         with pytest.raises(RuntimeError, match="GitHub API error 404"):
-            provider.github_read_diff(999)
+            provider._github_read_diff(999)
 
 
 # ============================================================
@@ -373,12 +532,12 @@ class TestMCPConfig:
 
 
 # ============================================================
-# LangChain tool wrapping via get_tools()
+# Dynamic LangChain tool wrapping via get_tools()
 # ============================================================
 
 
 class TestGetTools:
-    """Test that get_tools() produces valid LangChain Tools."""
+    """Test that get_tools() dynamically produces valid LangChain Tools."""
 
     @pytest.fixture
     def provider(self, tmp_path):
@@ -389,17 +548,11 @@ class TestGetTools:
         tools = get_tools(provider)
         assert len(tools) == 5
 
-    def test_tool_names(self, provider):
+    def test_tool_names_match_provider(self, provider):
         tools = get_tools(provider)
-        names = {t.name for t in tools}
-        expected = {
-            "filesystem_read",
-            "filesystem_write",
-            "filesystem_list",
-            "github_create_pr",
-            "github_read_diff",
-        }
-        assert names == expected
+        tool_names = {t.name for t in tools}
+        provider_names = {d.name for d in provider.list_tools()}
+        assert tool_names == provider_names
 
     def test_all_tools_have_descriptions(self, provider):
         tools = get_tools(provider)
@@ -426,58 +579,29 @@ class TestGetTools:
         result = list_tool.invoke(".")
         assert "test.txt" in result
 
-
-# ============================================================
-# JSON input parsing helpers
-# ============================================================
-
-
-class TestInputParsers:
-    """Test the JSON parsing helpers for write and create_pr tools."""
-
-    @pytest.fixture
-    def provider(self, tmp_path):
-        return LocalToolProvider(workspace_root=tmp_path)
-
-    def test_parse_write_valid(self, provider):
-        result = _parse_write_call(
-            provider, json.dumps({"path": "file.txt", "content": "hi"})
-        )
-        assert "Successfully wrote" in result
-
-    def test_parse_write_invalid_json(self, provider):
-        result = _parse_write_call(provider, "not json")
+    def test_multi_arg_tool_invalid_json(self, provider):
+        tools = get_tools(provider)
+        write_tool = next(t for t in tools if t.name == "filesystem_write")
+        result = write_tool.invoke("not json")
         assert "Error" in result
 
-    def test_parse_write_missing_keys(self, provider):
-        result = _parse_write_call(provider, json.dumps({"path": "file.txt"}))
-        assert "Error" in result
+    def test_works_with_any_provider(self, tmp_path):
+        """get_tools() works with any ToolProvider, not just LocalToolProvider."""
+        class MockProvider(ToolProvider):
+            def list_tools(self):
+                return [ToolDefinition(
+                    name="mock_tool",
+                    description="A mock tool",
+                    parameters={"type": "object", "properties": {"x": {"type": "string"}}, "required": ["x"]},
+                )]
+            def call_tool(self, name, arguments):
+                return f"mock result: {arguments.get('x')}"
 
-    @patch("src.tools.provider.httpx.post")
-    def test_parse_create_pr_valid(self, mock_post, tmp_path):
-        mock_post.return_value = MagicMock(
-            status_code=201,
-            json=lambda: {"number": 1, "html_url": "https://url"},
-        )
-        provider = LocalToolProvider(
-            workspace_root=tmp_path,
-            github_token="tok",
-            github_owner="owner",
-            github_repo="repo",
-        )
-        result = _parse_create_pr_call(
-            provider,
-            json.dumps({"title": "PR", "body": "desc", "head_branch": "feat"}),
-        )
-        assert "PR #1" in result
-
-    def test_parse_create_pr_invalid_json(self, provider):
-        result = _parse_create_pr_call(provider, "not json")
-        assert "Error" in result
-
-    def test_parse_create_pr_missing_keys(self, provider):
-        result = _parse_create_pr_call(provider, json.dumps({"title": "only"}))
-        assert "Error" in result
+        tools = get_tools(MockProvider())
+        assert len(tools) == 1
+        assert tools[0].name == "mock_tool"
+        result = tools[0].invoke("hello")
+        assert result == "mock result: hello"
 
 
 # ============================================================
@@ -488,41 +612,62 @@ class TestInputParsers:
 class TestFilesystemIntegration:
     """Integration tests with real temp directory operations."""
 
-    def test_full_round_trip(self):
-        """Write a file, list the directory, read it back."""
+    def test_full_round_trip_via_call_tool(self):
+        """Write a file, list the directory, read it back — all via call_tool."""
         with tempfile.TemporaryDirectory() as tmpdir:
             provider = LocalToolProvider(workspace_root=tmpdir)
 
             # Write
-            write_result = provider.filesystem_write(
-                "project/src/app.py", "def main():\n    pass\n"
+            write_result = provider.call_tool(
+                "filesystem_write",
+                {"path": "project/src/app.py", "content": "def main():\n    pass\n"},
             )
             assert "Successfully wrote" in write_result
 
             # List
-            list_result = provider.filesystem_list("project/src")
+            list_result = provider.call_tool(
+                "filesystem_list",
+                {"path": "project/src"},
+            )
             assert "app.py" in list_result
 
             # Read
-            read_result = provider.filesystem_read("project/src/app.py")
+            read_result = provider.call_tool(
+                "filesystem_read",
+                {"path": "project/src/app.py"},
+            )
             assert "def main():" in read_result
 
-    def test_overwrite_existing_file(self):
-        """Writing to an existing file overwrites it."""
+    def test_full_round_trip_via_private_methods(self):
+        """Write a file, list the directory, read it back — via private methods."""
         with tempfile.TemporaryDirectory() as tmpdir:
             provider = LocalToolProvider(workspace_root=tmpdir)
 
-            provider.filesystem_write("file.txt", "version 1")
-            provider.filesystem_write("file.txt", "version 2")
+            write_result = provider._filesystem_write(
+                "project/src/app.py", "def main():\n    pass\n"
+            )
+            assert "Successfully wrote" in write_result
 
-            content = provider.filesystem_read("file.txt")
+            list_result = provider._filesystem_list("project/src")
+            assert "app.py" in list_result
+
+            read_result = provider._filesystem_read("project/src/app.py")
+            assert "def main():" in read_result
+
+    def test_overwrite_existing_file(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            provider = LocalToolProvider(workspace_root=tmpdir)
+
+            provider.call_tool("filesystem_write", {"path": "file.txt", "content": "version 1"})
+            provider.call_tool("filesystem_write", {"path": "file.txt", "content": "version 2"})
+
+            content = provider.call_tool("filesystem_read", {"path": "file.txt"})
             assert content == "version 2"
 
     def test_empty_directory_listing(self):
-        """Listing an empty directory gives a clear message."""
         with tempfile.TemporaryDirectory() as tmpdir:
             provider = LocalToolProvider(workspace_root=tmpdir)
             (Path(tmpdir) / "empty_dir").mkdir()
 
-            result = provider.filesystem_list("empty_dir")
+            result = provider.call_tool("filesystem_list", {"path": "empty_dir"})
             assert "empty" in result.lower()


### PR DESCRIPTION
## Summary
Refactors the `ToolProvider` ABC from 5 hardcoded methods to a dynamic `list_tools()` + `call_tool()` interface. This prepares a clean foundation for `MCPToolProvider` (issue #13), which needs to expose tools dynamically from MCP server `tools/list` responses.

Closes #15

## What Changed

### `provider.py` — the core refactor
- **New `ToolDefinition` Pydantic model** — mirrors MCP `tools/list` response format (`name`, `description`, `parameters` as JSON Schema). MCPToolProvider can pass MCP `inputSchema` through without transformation.
- **New `ToolNotFoundError`** — clear error for unknown tool names (not generic `KeyError`)
- **`ToolProvider` ABC**: 5 methods → 2 methods (`list_tools()`, `call_tool()`)
- **`LocalToolProvider`**: registry-based dispatch pattern
  - `_tool_registry` dict maps tool names to `(ToolDefinition, handler)` tuples
  - `list_tools()` returns definitions from registry
  - `call_tool()` validates required args (Postel's Law: ignores extras), dispatches to private handlers
  - Original 5 implementations become private methods (`_filesystem_read`, etc.)

### `mcp_bridge.py` — dynamic tool generation
- **`get_tools()` is now fully dynamic** — iterates `provider.list_tools()` and auto-generates LangChain `Tool` objects
- **Auto-detects single-arg vs multi-arg tools** — single required string param gets raw string passthrough, everything else gets JSON parsing
- **Hardcoded tool list eliminated** — works identically for any provider returning any set of tools
- **`_parse_write_call` / `_parse_create_pr_call` removed** — replaced by generic `_make_multi_arg_handler`

### `__init__.py` — new exports
- Exports `ToolDefinition` and `ToolNotFoundError`

### `test_mcp_tools.py` — 67 tests (was 40)
Tests are organized in two layers as a deliberate design choice:
- **Interface layer** (`TestListTools`, `TestCallTool`): tests `list_tools()` and `call_tool()` dispatch, validation, error handling
- **Implementation layer** (`TestLocalToolProviderFilesystem`, `TestLocalToolProviderGitHub`): tests private handler methods directly for precise failure isolation
- **New test classes**: `TestToolDefinition`, `TestListTools`, `TestCallTool` with dispatch, unknown tool, missing args, extra args (Postel's Law), and mock provider tests
- **`TestGetTools.test_works_with_any_provider`** — proves `get_tools()` works with a custom `ToolProvider` subclass, not just `LocalToolProvider`

## Design Decisions

**Why both private method tests AND call_tool tests?** Migrating all existing tests to `call_tool()` would conflate dispatch testing with implementation testing. If `call_tool` routing breaks, 20 filesystem tests fail and you can't tell if the problem is path validation or routing. Testing at both layers gives precise failure isolation.

**Why validate required args only (ignore extras)?** Postel's Law — strict in what you produce, lenient in what you accept. Catches real bugs (agent forgot `path`) while not breaking when an MCP server sends extra metadata fields or future tool versions add optional params.

**Why JSON Schema for parameters?** MCP's `tools/list` returns `inputSchema` in JSON Schema format. Using the same format means `MCPToolProvider` (#13) can pass schemas through verbatim with zero transformation.

## Test Results
```
67 passed in 1.61s
```

## Backward Compatibility
- Same 5 tool names preserved (`filesystem_read`, `filesystem_write`, `filesystem_list`, `github_create_pr`, `github_read_diff`)
- `get_tools()` returns Tools with identical names and behavior
- Orchestrator and E2E tests unaffected (they don't reference tools directly)