### PR TITLE
feat(dashboard): #38 PR2 — Wire StatusBar to live stores

### DIFF
--- a/dashboard/src/lib/components/StatusBar.svelte
+++ b/dashboard/src/lib/components/StatusBar.svelte
@@ -1,19 +1,62 @@
+<!--
+	StatusBar — bottom chrome bar showing live system state.
+
+	Reads from:
+	- agentsStore.list     → agent dots + statuses
+	- tasksStore.list      → token budget, cost, retries (latest task)
+	- connection.status    → connection indicator dot
+
+	Issue #38: Data Integration — PR2 StatusBar + ActivityBar
+-->
 <script lang="ts">
-	const agents = [
-		{ name: 'Architect', status: 'idle' },
-		{ name: 'Lead Dev', status: 'coding' },
-		{ name: 'QA Agent', status: 'waiting' }
-	];
+	import { agentsStore } from '$lib/stores/agents.svelte.js';
+	import { tasksStore } from '$lib/stores/tasks.svelte.js';
+	import { connection } from '$lib/stores/connection.svelte.js';
+	import type { AgentStatus } from '$lib/types/api.js';
 
 	const statusColors: Record<string, string> = {
 		idle: 'var(--color-text-dim)',
+		planning: 'var(--color-accent-cyan)',
 		coding: 'var(--color-accent-purple)',
+		reviewing: 'var(--color-accent-yellow)',
 		waiting: 'var(--color-accent-yellow)',
 		testing: 'var(--color-accent-green)',
 		error: 'var(--color-accent-red)'
 	};
 
-	const aliveStatuses = ['coding', 'testing'];
+	const aliveStatuses: AgentStatus[] = ['planning', 'coding', 'reviewing'];
+
+	// Latest task budget (most recent task, or fallback zeros)
+	const latestBudget = $derived(() => {
+		const list = tasksStore.list;
+		if (list.length === 0) {
+			return { tokens_used: 0, token_budget: 0, retries_used: 0, max_retries: 3, cost_used: 0, cost_budget: 1.0 };
+		}
+		// Prefer the active task; otherwise the most recent
+		const active = tasksStore.activeTasks;
+		const task = active.length > 0 ? active[active.length - 1] : list[list.length - 1];
+		return task.budget;
+	});
+
+	const tokenPct = $derived(() => {
+		const b = latestBudget();
+		return b.token_budget > 0 ? Math.round((b.tokens_used / b.token_budget) * 100) : 0;
+	});
+
+	const barColor = $derived(() => {
+		const pct = tokenPct();
+		if (pct > 90) return 'var(--color-accent-red)';
+		if (pct > 75) return 'var(--color-accent-amber)';
+		return 'var(--color-accent-cyan)';
+	});
+
+	const connectionDotColor = $derived(() => {
+		switch (connection.status) {
+			case 'connected': return 'var(--color-accent-green)';
+			case 'reconnecting': return 'var(--color-accent-amber)';
+			default: return 'var(--color-accent-red)';
+		}
+	});
 </script>
 
 <div
@@ -22,9 +65,19 @@
 >
 	<!-- Left side -->
 	<div class="flex items-center gap-3.5 text-[10px] text-white" style="font-family: var(--font-mono);">
-		<span>LangGraph v0.4</span>
+		<!-- Connection indicator -->
+		<span class="flex items-center gap-1">
+			<span
+				class="inline-block h-[7px] w-[7px] rounded-full"
+				style="
+					background: {connectionDotColor()};
+					animation: {connection.status === 'reconnecting' ? 'pulse 1.5s ease-in-out infinite' : 'none'};
+				"
+			></span>
+			<span class="opacity-90">LangGraph</span>
+		</span>
 		<span class="opacity-70">|</span>
-		{#each agents as agent (agent.name)}
+		{#each agentsStore.list as agent (agent.id)}
 			<span class="flex items-center gap-1">
 				<span
 					class="inline-block h-[7px] w-[7px] rounded-full"
@@ -37,6 +90,9 @@
 				<span class="opacity-90">{agent.name}</span>
 			</span>
 		{/each}
+		{#if agentsStore.list.length === 0}
+			<span class="opacity-50">No agents</span>
+		{/if}
 	</div>
 
 	<!-- Right side -->
@@ -46,22 +102,26 @@
 	>
 		<span>Sandbox: locked-down</span>
 		<span class="opacity-50">|</span>
-		<span class="flex items-center gap-1.5">
-			<span>Tokens:</span>
-			<span
-				class="inline-block h-1 w-[50px] overflow-hidden rounded-sm"
-				style="background: rgba(255,255,255,0.2);"
-			>
+		{#if latestBudget().token_budget > 0}
+			<span class="flex items-center gap-1.5">
+				<span>Tokens:</span>
 				<span
-					class="block h-full rounded-sm"
-					style="width: 76%; background: var(--color-accent-amber);"
-				></span>
+					class="inline-block h-1 w-[50px] overflow-hidden rounded-sm"
+					style="background: rgba(255,255,255,0.2);"
+				>
+					<span
+						class="block h-full rounded-sm transition-all duration-300"
+						style="width: {tokenPct()}%; background: {barColor()};"
+					></span>
+				</span>
+				<span style="color: {barColor()};">{tokenPct()}%</span>
 			</span>
-			<span style="color: var(--color-accent-amber);">76%</span>
-		</span>
-		<span class="opacity-50">|</span>
-		<span>$0.47</span>
-		<span class="opacity-50">|</span>
-		<span>Retries: 1/3</span>
+			<span class="opacity-50">|</span>
+			<span>${latestBudget().cost_used.toFixed(2)}</span>
+			<span class="opacity-50">|</span>
+			<span>Retries: {latestBudget().retries_used}/{latestBudget().max_retries}</span>
+		{:else}
+			<span class="opacity-50">No active task</span>
+		{/if}
 	</div>
 </div>


### PR DESCRIPTION
## Summary
Wire the StatusBar component to live store data, replacing all hardcoded mock values. This is **PR 2 of 4** for #38.

Stacked on: #42 (PR1 Bootstrap)

## Changes

### StatusBar.svelte — fully rewritten
**Before:** Hardcoded 3-agent array, fixed 76% token bar, fixed $0.47 cost, fixed 1/3 retries.

**After:** Every value is reactive and `$derived` from stores:

| Element | Data Source |
|---|---|
| Connection dot (green/amber/red) | `connection.status` |
| Agent dots + names | `agentsStore.list` (iterated by `agent.id`) |
| Agent status pulse animation | `aliveStatuses` includes `planning`, `coding`, `reviewing` |
| Token usage % bar | `$derived` from latest/active task's `budget.tokens_used / budget.token_budget` |
| Token bar color | cyan < 75%, amber 75-90%, red > 90% |
| Cost display | `budget.cost_used` |
| Retry count | `budget.retries_used / budget.max_retries` |
| Empty state | "No agents" when store empty, "No active task" when no tasks exist |

### ActivityBar.svelte — no changes needed
PR1 already wired the badge counts via `$derived(memoryStore.pendingCount)` and `$derived(prsStore.openCount)` in the layout, which flow through as props to ActivityBar. Nothing more to do here.

## Build Verification
- `svelte-check`: 0 errors, 0 warnings
- `vite build`: clean

## PR Series for #38
- PR 1: Bootstrap ✅ (#42)
- **→ PR 2 (this): StatusBar + ActivityBar**
- PR 3: SidebarPanel + Main Views
- PR 4: Chat + Terminal

Refs: #38