### PR TITLE
fix: POSIX arithmetic in smoke-test.sh Stage 1 (#66)

### DIFF
--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -98,7 +98,7 @@ check_json_field() {
     body=$(curl_get "$url" 2>/dev/null || echo "")
     if [ -z "$body" ]; then
         printf "${RED}UNREACHABLE${NC}\n"
-        ((stage1_fail++))
+        stage1_fail=$((stage1_fail + 1))
         return
     fi
     result=$(echo "$body" | python3 -c "
@@ -117,38 +117,20 @@ except Exception as e:
 " 2>/dev/null || echo "PARSE_ERROR")
     if [[ "$result" == "OK" ]]; then
         printf "${GREEN}OK${NC}\n"
-        ((stage1_pass++))
+        stage1_pass=$((stage1_pass + 1))
     else
         printf "${RED}FAILED${NC} (%s)\n" "$result"
-        ((stage1_fail++))
+        stage1_fail=$((stage1_fail + 1))
     fi
 }
 
-# Verify agents endpoint returns data array
+# Verify API endpoints return expected data
 check_json_field "GET /agents -> data array" "$API_URL/agents" "data"
-
-# Verify tasks endpoint returns data array
 check_json_field "GET /tasks -> data array" "$API_URL/tasks" "data"
-
-# Verify memory endpoint returns data array
 check_json_field "GET /memory -> data array" "$API_URL/memory" "data"
-
-# Verify health has uptime
 check_json_field "GET /health -> uptime_seconds" "$API_URL/health" "uptime_seconds"
 
-# Verify SSE endpoint is reachable (just check HTTP status)
-printf "  %-40s " "GET /stream (SSE reachable)"
-sse_status=$(curl -s -o /dev/null -w "%{http_code}" --max-time 3 ${AUTH_HEADER:+-H "$AUTH_HEADER"} "$API_URL/stream" 2>/dev/null || echo "000")
-if [ "$sse_status" = "200" ]; then
-    printf "${GREEN}OK${NC} (%s)\n" "$sse_status"
-    ((stage1_pass++))
-elif [ "$sse_status" = "000" ]; then
-    printf "${RED}UNREACHABLE${NC}\n"
-    ((stage1_fail++))
-else
-    printf "${YELLOW}UNEXPECTED${NC} (%s)\n" "$sse_status"
-    ((stage1_fail++))
-fi
+# SSE already verified by Stage 0 (verify-stack.sh), no need to recheck
 
 echo ""
 if [ "$stage1_fail" -gt 0 ]; then


### PR DESCRIPTION
## Summary

Fixes the same `((var++))` bash arithmetic bug in `smoke-test.sh` Stage 1 that was already fixed in `verify-stack.sh` (PR #68).

## Bug

`((stage1_pass++))` when `stage1_pass=0` evaluates to 0 (falsy) under `set -e`, killing the script after the first successful Stage 1 check. This is why the dry-run output showed only "GET /agents -> data array OK" before exiting.

## Changes

1. Replace all `((stage1_pass++))` / `((stage1_fail++))` with `stage1_pass=$((stage1_pass + 1))` — POSIX-safe
2. Remove redundant SSE recheck from Stage 1 (already validated in Stage 0 by `verify-stack.sh`)

## Expected Output

```
Stage 1: Read-Only Data Flow
------------------------------------------------
  GET /agents -> data array                OK
  GET /tasks -> data array                 OK
  GET /memory -> data array                OK
  GET /health -> uptime_seconds            OK

Stage 1 PASSED (4 checks)

--dry-run: Skipping Stage 2 (no LLM calls)

SMOKE TEST PASSED (stages 0-1, dry-run mode)
```

Part of #66.