### PR TITLE
fix(dashboard): remove broken connectionStore import crashing page (#66)

### DIFF
--- a/dashboard/src/lib/components/StatusBar.svelte
+++ b/dashboard/src/lib/components/StatusBar.svelte
@@ -9,7 +9,6 @@
 <script lang="ts">
 	import { agentsStore } from '$lib/stores/agents.svelte.js';
 	import { tasksStore } from '$lib/stores/tasks.svelte.js';
-	import { connectionStore } from '$lib/stores/connection.svelte.js';
 
 	const statusColors: Record<string, string> = {
 		idle: 'var(--color-text-dim)',


### PR DESCRIPTION
## Summary

Fixes a broken import in `StatusBar.svelte` that crashes the entire dashboard on page load.

## Bug

```
SyntaxError: The requested module '/src/lib/stores/connection.svelte.ts' 
does not provide an export named 'connectionStore'
```

`StatusBar.svelte` line 12 imports `connectionStore`, but the connection store exports `connection`. The import was also completely unused — no code in StatusBar references it. This caused a hydration crash that prevented any rendering, making the dashboard completely non-functional.

## Fix

Remove the unused bad import. The component only needs `agentsStore` and `tasksStore`, both of which were already imported correctly.

## Impact

This was the root cause of the "Backend unreachable" + empty dashboard seen during #66 Stage 3-4 manual testing. The SSE client, stores, and proxy routes are all fine — the page just crashed before they could run.

Part of #66.