### PR TITLE
chore(ci): remove stale -k test exclusions (#81)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,6 @@ jobs:
           uv run pytest tests/ -v --tb=short
           -m "not integration"
           --ignore=tests/test_e2e_live.py
-          -k "not (test_get_live_prs_fallback_no_token or test_approve_memory_emits or test_reject_memory_emits)"
         env:
           ANTHROPIC_API_KEY: test-key-not-real
           GOOGLE_API_KEY: test-key-not-real


### PR DESCRIPTION
## Summary

Removes the stale `-k` test exclusion filter from `ci.yml`. All 3 previously-excluded tests were already fixed in PR #77 (merged March 31).

## What Changed

### `.github/workflows/ci.yml`
Removed this line from the pytest command:
```
-k "not (test_get_live_prs_fallback_no_token or test_approve_memory_emits or test_reject_memory_emits)"
```

### Why Each Exclusion Is Safe to Remove

| Excluded Test | Status | Resolution |
|---|---|---|
| `test_get_live_prs_fallback_no_token` | **Does not exist** | Renamed to `test_get_live_prs_no_token_returns_empty` in PR #77. New test correctly asserts empty list (no mock-data fallback). |
| `test_approve_memory_emits` | **Fixed** | PR #77 seeds `state_manager._memory["mem-1"]` before calling approve. Passes reliably. |
| `test_reject_memory_emits` | **Fixed** | PR #77 seeds `state_manager._memory["mem-3"]` before calling reject. Passes reliably. |

## Acceptance Criteria (from #81)

- [x] The 2 SSE memory emission tests pass without `-k` exclusion (fixed in PR #77)
- [x] `test_get_live_prs_fallback_no_token` exclusion removed (test no longer exists)
- [x] CI `-k` filter removed entirely from `ci.yml`
- [x] Zero `@pytest.mark.skip` decorators in non-platform-conditional tests
- [x] All 486+ existing tests still pass

## Test Command (after this PR)

```yaml
uv run pytest tests/ -v --tb=short
  -m "not integration"
  --ignore=tests/test_e2e_live.py
```

Clean. No `-k` exclusions. Integration tests properly gated behind `@pytest.mark.integration`. Live E2E properly gated behind `--ignore`.

Closes #81

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage in the continuous integration pipeline by enabling additional unit tests that were previously excluded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->