### PR TITLE
feat(dashboard): add top MenuBar + reorder ActivityBar

### DIFF
--- a/dashboard/src/lib/components/ActivityBar.svelte
+++ b/dashboard/src/lib/components/ActivityBar.svelte
@@ -11,10 +11,10 @@
 	let { activePanel, onSelect, pendingMemory = 0, pendingPR = 0 }: Props = $props();
 
 	const items: { id: PanelId; label: string; badge: number }[] = $derived([
+		{ id: 'chat', label: 'Ch', badge: 0 },
 		{ id: 'agents', label: 'Ag', badge: 0 },
 		{ id: 'memory', label: 'Mm', badge: pendingMemory },
-		{ id: 'prs', label: 'PR', badge: pendingPR },
-		{ id: 'chat', label: 'Ch', badge: 0 }
+		{ id: 'prs', label: 'PR', badge: pendingPR }
 	]);
 </script>
 

--- a/dashboard/src/lib/components/MenuBar.svelte
+++ b/dashboard/src/lib/components/MenuBar.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+	const menuItems = ['File', 'Edit', 'View'];
+</script>
+
+<div
+	class="flex h-[30px] shrink-0 items-center border-b px-3 gap-4 select-none"
+	style="background: var(--color-bg-activity); border-color: var(--color-border); font-family: var(--font-mono);"
+>
+	<span
+		class="text-[11px] font-semibold tracking-wide"
+		style="color: var(--color-accent-cyan);"
+	>
+		dev-suite
+	</span>
+
+	<div class="flex items-center gap-3">
+		{#each menuItems as item}
+			<span
+				class="text-[10px] cursor-default"
+				style="color: var(--color-text-dim);"
+			>
+				{item}
+			</span>
+		{/each}
+	</div>
+
+	<div class="flex-1"></div>
+</div>

--- a/dashboard/src/routes/+layout.svelte
+++ b/dashboard/src/routes/+layout.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import '../app.css';
 	import { onMount } from 'svelte';
+	import MenuBar from '$lib/components/MenuBar.svelte';
 	import ActivityBar from '$lib/components/ActivityBar.svelte';
 	import SidebarPanel from '$lib/components/SidebarPanel.svelte';
 	import BottomPanel from '$lib/components/BottomPanel.svelte';
@@ -35,6 +36,8 @@
 </svelte:head>
 
 <div class="flex h-screen flex-col overflow-hidden" style="background: var(--color-bg-primary);">
+	<MenuBar />
+
 	<div class="flex flex-1 overflow-hidden">
 		<ActivityBar
 			activePanel={dash.activePanel}


### PR DESCRIPTION
## Summary

Two UI changes to the SvelteKit dashboard:

### 1. Top Menu Bar
- New `MenuBar.svelte` component — slim 30px bar at the very top of the layout
- Left side: **dev-suite** title in cyan accent
- Placeholder menu items (File, Edit, View) rendered as inactive spans — ready for future wiring
- Uses existing design tokens (`--color-bg-activity`, `--color-border`, `--font-mono`)

### 2. Chat moved to top of ActivityBar
- Reordered `items` array: **Chat → Agents → Memory → PRs**
- Chat is now the first icon in the left activity bar instead of last

### Files changed
| File | Change |
|---|---|
| `dashboard/src/lib/components/MenuBar.svelte` | **New** — top menu bar component |
| `dashboard/src/lib/components/ActivityBar.svelte` | Reorder: chat first |
| `dashboard/src/routes/+layout.svelte` | Import + render MenuBar above main content |

No backend changes, no store changes, no routing changes. Pure UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new menu bar to the dashboard with File, Edit, and View menu items.

* **Style**
  * Reordered activity bar items: Chat moved to the beginning, Pull Requests moved to the end.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->