### PR TITLE
fix(sandbox): use Sandbox.create() classmethod instead of constructor (#96)

### DIFF
--- a/dev-suite/src/sandbox/e2b_runner.py
+++ b/dev-suite/src/sandbox/e2b_runner.py
@@ -19,6 +19,8 @@ Issue #96: Migrated from e2b_code_interpreter (Jupyter kernel on port 49999)
 to base e2b SDK (commands.run). Eliminates kernel timeout errors entirely.
 Uses sbx.files.write() for project files and sbx.commands.run() for
 shell execution. No more base64 encoding or subprocess wrappers.
+Must use Sandbox.create() classmethod (not constructor) -- the constructor
+does not accept template/envs kwargs in the installed SDK version.
 """
 
 import logging
@@ -204,6 +206,31 @@ def select_template_for_files(target_files: list[str]) -> str | None:
     return "fullstack" if has_frontend else None
 
 
+# -- Sandbox Creation Helper --
+
+def _create_sandbox(
+    template: str | None = None,
+    env_vars: dict[str, str] | None = None,
+) -> Sandbox:
+    """Create a sandbox via Sandbox.create() classmethod.
+
+    IMPORTANT: Must use Sandbox.create(), not the Sandbox() constructor.
+    The constructor (SandboxBase.__init__) does not accept template/envs
+    kwargs -- only the create() classmethod does.
+
+    Env vars are injected at sandbox creation time via the envs param,
+    which is more secure than setting them via shell commands.
+    """
+    create_kwargs: dict = {}
+    template_id = _get_template_id(template)
+    if template_id:
+        create_kwargs["template"] = template_id
+    if env_vars:
+        create_kwargs["envs"] = env_vars
+    logger.info("[SANDBOX] Creating sandbox: template=%s, envs=%s", template_id, bool(env_vars))
+    return Sandbox.create(**create_kwargs)
+
+
 # -- File Upload Helper --
 
 def _write_project_files(sbx: Sandbox, project_files: dict[str, str]) -> None:
@@ -226,8 +253,9 @@ def _write_project_files(sbx: Sandbox, project_files: dict[str, str]) -> None:
 class E2BRunner:
     """Execute code in E2B sandboxes with structured output.
 
-    Uses the base e2b SDK with commands.run() for shell execution.
-    No Jupyter kernel dependency (port 49999 eliminated).
+    Uses the base e2b SDK with Sandbox.create() + commands.run()
+    for shell execution. No Jupyter kernel dependency (port 49999
+    eliminated).
 
     Usage:
         runner = E2BRunner()
@@ -239,24 +267,6 @@ class E2BRunner:
         if api_key:
             os.environ["E2B_API_KEY"] = api_key
         self._default_timeout = default_timeout
-
-    def _create_sandbox(
-        self,
-        template: str | None = None,
-        env_vars: dict[str, str] | None = None,
-    ) -> Sandbox:
-        """Create a sandbox with optional template and env vars.
-
-        Env vars are injected at sandbox creation time via the `envs` param,
-        which is more secure than setting them via shell commands.
-        """
-        create_kwargs: dict = {}
-        template_id = _get_template_id(template)
-        if template_id:
-            create_kwargs["template"] = template_id
-        if env_vars:
-            create_kwargs["envs"] = env_vars
-        return Sandbox(**create_kwargs)
 
     def _build_result(
         self,
@@ -302,7 +312,7 @@ class E2BRunner:
         (e.g., pytest) from running. Results are aggregated.
         """
         try:
-            with self._create_sandbox(template=template, env_vars=env_vars) as sbx:
+            with _create_sandbox(template=template, env_vars=env_vars) as sbx:
                 if project_files:
                     _write_project_files(sbx, project_files)
 
@@ -382,7 +392,7 @@ class E2BRunner:
         wrapper, no __EXIT_CODE__ trailer parsing.
         """
         try:
-            with self._create_sandbox(template=template, env_vars=env_vars) as sbx:
+            with _create_sandbox(template=template, env_vars=env_vars) as sbx:
                 if project_files:
                     _write_project_files(sbx, project_files)
 


### PR DESCRIPTION
## Problem

The previous commit (`bccadf0`) migrated from `e2b_code_interpreter` to the base `e2b` SDK but used the `Sandbox()` constructor instead of `Sandbox.create()`. The constructor (`SandboxBase.__init__`) does not accept `template` or `envs` kwargs — only the `create()` classmethod does.

This caused a `TypeError` on every sandbox validation:
```
SandboxBase.__init__() got an unexpected keyword argument 'template'
```

Confirmed via Langfuse trace (`task-6f80243b`): all 3 `sandbox_validate` spans show `lat=0.00s` — the sandbox never starts, the error is caught immediately.

**Env context:** `E2B_TEMPLATE_DEFAULT=fullstack-dev` and `E2B_TEMPLATE_FULLSTACK=fullstack-dev` are both set in `dev-suite/.env`, so `_get_template_id(None)` always resolves to `"fullstack-dev"`, which gets passed as `template=` kwarg.

## Fix

- `Sandbox(**create_kwargs)` → `Sandbox.create(**create_kwargs)` in `_create_sandbox()`
- Extracted `_create_sandbox()` to module-level function (was previously `E2BRunner._create_sandbox()`) for cleaner separation
- Added `logger.info` call for sandbox creation visibility

## Testing

Pull branch, restart API, submit "Write a simple hello world in python" from dashboard. Sandbox should now start and validate successfully.

Closes #96

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured sandbox creation logic for improved maintainability. The sandbox initialization process has been optimized internally while maintaining the same functionality and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->