### PR TITLE
fix(code_parser): strip markdown fences from parsed file content (#101)

### DIFF
--- a/dev-suite/src/tools/code_parser.py
+++ b/dev-suite/src/tools/code_parser.py
@@ -26,9 +26,10 @@ _FILE_MARKER_RE = re.compile(
     re.MULTILINE,
 )
 
-# Matches a markdown fence line: ```python, ```js, ```, etc.
+# Matches a markdown fence line: ```python, ```c++, ```objective-c, ```, etc.
+# Supports info strings with non-word chars (hyphens, pluses).
 # Only anchored at line boundaries -- used to strip leading/trailing fences.
-_FENCE_RE = re.compile(r"^```\w*\s*$")
+_FENCE_RE = re.compile(r"^\s*```(?:[^`\s][^`]*)?\s*$")
 
 
 @dataclass(frozen=True)
@@ -160,6 +161,8 @@ def parse_generated_code(
     if not markers:
         # No markers -- treat entire output as single file
         content = generated_code.strip()
+        content = _strip_markdown_fences(content, default_filename)
+        content = content.strip("\n").rstrip()
         if not content:
             return []
         return [ParsedFile(path=default_filename, content=content)]

--- a/dev-suite/tests/test_code_parser.py
+++ b/dev-suite/tests/test_code_parser.py
@@ -129,6 +129,18 @@ class TestStripMarkdownFences:
     def test_empty_content(self):
         assert _strip_markdown_fences("", "test.py") == ""
 
+    def test_strips_cpp_fence(self):
+        """Fences with non-word info strings like c++ are stripped."""
+        content = "```c++\n#include <iostream>\nint main() { return 0; }\n```"
+        result = _strip_markdown_fences(content, "test.cpp")
+        assert result == "#include <iostream>\nint main() { return 0; }"
+
+    def test_strips_objective_c_fence(self):
+        """Fences with hyphenated info strings like objective-c are stripped."""
+        content = "```objective-c\n@implementation Foo\n@end\n```"
+        result = _strip_markdown_fences(content, "test.m")
+        assert result == "@implementation Foo\n@end"
+
     def test_fence_with_trailing_whitespace(self):
         content = "```python   \ndef hello():\n    pass\n```  "
         result = _strip_markdown_fences(content, "test.py")
@@ -400,6 +412,21 @@ class TestParseGeneratedCode:
         assert "```" not in result[0].content
         # Must be valid Python (no SyntaxError)
         compile(result[0].content, "triforce.py", "exec")
+
+    def test_no_markers_with_fences_stripped(self):
+        """Marker-less output wrapped in fences is cleaned."""
+        code = (
+            "```python\n"
+            "def hello():\n"
+            "    print('hi')\n"
+            "```"
+        )
+        result = parse_generated_code(code)
+        assert len(result) == 1
+        assert result[0].path == "output.py"
+        assert not result[0].content.startswith("```")
+        assert "def hello():" in result[0].content
+        assert "```" not in result[0].content
 
     def test_interior_backticks_preserved(self):
         """Triple backticks inside file content (not first/last line) survive."""


### PR DESCRIPTION
## Summary

Fixes #101 — `code_parser.py` doesn't strip markdown triple-backtick fences from parsed file content.

## Problem

LLMs frequently wrap code in ` ```lang...``` ` fences even inside `# --- FILE:` marker sections. The code parser extracted this fence as part of the file content, causing `SyntaxError` when the file was executed in the E2B sandbox.

**Root cause confirmed via Langfuse trace** (`trace-2779973899882ec73c9b4eb161ae53f5`, task `task-c7a57086`):

1. Developer agent writes **clean** Python via `filesystem_write` tool (no fences) ✅
2. But `generated_code` text output wraps it in: `# --- FILE: triforce.py ---\n```python\n...`
3. `apply_code_node` calls `code_parser` on `generated_code` → fences stay in `parsed_files`
4. `apply_code_node` **overwrites** workspace with fence-contaminated content
5. Sandbox runs file → `SyntaxError: invalid syntax` on line 1 (` ```python `)
6. **All 3 retries fail identically** — the developer can't fix what code_parser re-introduces

This burned 32,486 tokens and 82.7 seconds on a task the agents literally could not work around.

## Changes

### `dev-suite/src/tools/code_parser.py`
- Add `_FENCE_RE` pattern matching ` ```\w*\s* ` at line boundaries
- Add `_strip_markdown_fences(content, path)` helper function
- Only strips **first** and **last** lines if they match the fence pattern
- Interior backticks (e.g., in README templates) are preserved
- Logs `code_parser: stripped markdown fences from {path}` when fences are stripped
- Called per-block after initial extraction, with re-strip for exposed whitespace

### `dev-suite/tests/test_code_parser.py`
- **New `TestStripMarkdownFences` class** (10 tests): python/js/sql/bare fences, interior backtick preservation, leading-only, trailing-only, empty content, trailing whitespace
- **6 integration tests** in `TestParseGeneratedCode`: fence stripping through full parse pipeline, mixed fence/clean files, regression test from exact trace pattern
- Regression test uses `compile()` to validate parsed output is executable Python
- **47 tests total, all passing**

## Test Results

```
47 passed, 1 warning in 0.19s
```

(Warning is a benign `SyntaxWarning` from backslash sequences in the ASCII art test fixture, not a real issue.)

## Labels
`bug`, `pipeline`

## Milestone
Phase 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved code extraction to detect and remove surrounding Markdown code-fence syntax from parsed file contents (including cases adjacent to file markers), trim extraneous whitespace, and preserve interior fenced blocks, resulting in cleaner, ready-to-use code output.

* **Tests**
  * Added comprehensive test coverage for fence-stripping behavior, edge cases, mixed file layouts, and regressions across multiple language variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->