### PR TITLE
feat: multi-file task decomposition (Architect sub-task sequencing)

### DIFF
--- a/dev-suite/src/agents/architect.py
+++ b/dev-suite/src/agents/architect.py
@@ -23,8 +23,21 @@ class Blueprint(BaseModel):
     acceptance_criteria: list[str]
 
 
-# TODO Step 4:
-# - Define architect prompt template
-# - Configure Gemini model via langchain-google-genai
-# - Implement blueprint generation with structured output
-# - Wire into LangGraph node
+class SubTask(BaseModel):
+    """A single sub-task within a multi-file task decomposition."""
+
+    sub_task_id: str
+    parent_task_id: str
+    sequence: int
+    depends_on: list[str] = []
+    target_files: list[str]
+    instructions: str
+    description: str
+
+
+class TaskDecomposition(BaseModel):
+    """Decomposition of a complex task into ordered sub-tasks."""
+
+    parent_task_id: str
+    sub_tasks: list[SubTask]
+    rationale: str

--- a/dev-suite/src/orchestrator.py
+++ b/dev-suite/src/orchestrator.py
@@ -44,7 +44,7 @@ from langchain_google_genai import ChatGoogleGenerativeAI
 from langgraph.graph import END, START, StateGraph
 from pydantic import BaseModel
 
-from .agents.architect import Blueprint
+from .agents.architect import Blueprint, TaskDecomposition
 from .agents.qa import FailureReport
 from .memory.factory import create_memory_store
 from .memory.protocol import MemoryStore
@@ -85,6 +85,8 @@ MAX_RETRY_FILE_CHARS = _safe_int("MAX_RETRY_FILE_CHARS", 30000)
 CONTEXT_BUDGET_CHARS = _safe_int("CONTEXT_BUDGET_CHARS", 120000)  # ~30k tokens
 CONTEXT_FILE_MAX_LINES = _safe_int("CONTEXT_FILE_MAX_LINES", 500)
 CONTEXT_FILE_TAIL_LINES = _safe_int("CONTEXT_FILE_TAIL_LINES", 50)
+DECOMPOSE_FILE_THRESHOLD = _safe_int("DECOMPOSE_FILE_THRESHOLD", 5)
+DECOMPOSE_DIR_THRESHOLD = _safe_int("DECOMPOSE_DIR_THRESHOLD", 2)
 
 
 def _get_workspace_root() -> Path:
@@ -127,6 +129,9 @@ class GraphState(TypedDict, total=False):
     pr_url: str | None
     pr_number: int | None
     gathered_context: list[dict] | None
+    decomposition: TaskDecomposition | None
+    current_subtask_index: int
+    completed_subtasks: list[dict]
 
 
 class AgentState(BaseModel):
@@ -154,6 +159,9 @@ class AgentState(BaseModel):
     pr_url: str | None = None
     pr_number: int | None = None
     gathered_context: list[dict] | None = None
+    decomposition: TaskDecomposition | None = None
+    current_subtask_index: int = 0
+    completed_subtasks: list[dict] = []
 
 
 # -- LLM Provider Auto-Detection --
@@ -656,6 +664,125 @@ async def gather_context_node(state: GraphState) -> dict:
     return {"gathered_context": gathered, "trace": trace}
 
 
+# -- Task Decomposition (Issue #58) --
+
+def _needs_decomposition(task_description: str, gathered_context: list[dict] | None) -> bool:
+    """Determine if a task is large enough to warrant decomposition.
+
+    Returns True if gathered context has >= DECOMPOSE_FILE_THRESHOLD files
+    OR files span >= DECOMPOSE_DIR_THRESHOLD top-level directories.
+    """
+    if not gathered_context:
+        return False
+    file_paths = [ctx["path"] for ctx in gathered_context]
+    if len(file_paths) >= DECOMPOSE_FILE_THRESHOLD:
+        return True
+    top_dirs = {p.split("/")[0] for p in file_paths if "/" in p}
+    return len(top_dirs) >= DECOMPOSE_DIR_THRESHOLD
+
+
+def _build_decomposition_prompt(task_description: str, file_paths: list[str]) -> str:
+    """Build the system prompt for the decomposition LLM call."""
+    files_block = "\n".join(f"- {p}" for p in file_paths)
+    return f"""You are a task decomposition specialist. Given a complex coding task and the relevant files,
+break it down into sequenced sub-tasks that can each be implemented and tested independently.
+
+Each sub-task should:
+- Target a coherent subset of files (ideally within one module/directory)
+- Have clear instructions that can stand alone
+- List dependencies on prior sub-tasks
+
+Respond with ONLY a valid JSON object matching this schema:
+{{
+  "parent_task_id": "string (short ID for the overall task)",
+  "sub_tasks": [
+    {{
+      "sub_task_id": "string (e.g. parent_task_id-1)",
+      "parent_task_id": "string (same as above)",
+      "sequence": 0,
+      "depends_on": [],
+      "target_files": ["list of file paths for this sub-task"],
+      "instructions": "detailed instructions for this sub-task",
+      "description": "one-line summary"
+    }}
+  ],
+  "rationale": "why this decomposition was chosen"
+}}
+
+Do not include any text before or after the JSON.
+
+## Relevant Files
+{files_block}"""
+
+
+async def decompose_task_node(state: GraphState) -> dict:
+    """Decompose large tasks into ordered sub-tasks (Issue #58).
+
+    For tasks below the threshold, passes through with decomposition=None.
+    For large tasks, calls the architect LLM to produce a TaskDecomposition.
+    """
+    trace = list(state.get("trace", []))
+    trace.append("decompose_task: evaluating scope")
+
+    task_description = state.get("task_description", "")
+    gathered_context = state.get("gathered_context") or []
+
+    if not _needs_decomposition(task_description, gathered_context):
+        trace.append("decompose_task: below threshold, skipping decomposition")
+        logger.info("[DECOMPOSE] Task below decomposition threshold, single-blueprint path")
+        return {"decomposition": None, "current_subtask_index": 0, "completed_subtasks": [], "trace": trace}
+
+    file_paths = [ctx["path"] for ctx in gathered_context]
+    trace.append(f"decompose_task: {len(file_paths)} files detected, decomposing")
+    logger.info("[DECOMPOSE] %d files across workspace, invoking LLM decomposition", len(file_paths))
+
+    system_prompt = _build_decomposition_prompt(task_description, file_paths)
+    llm = _get_architect_llm()
+    tokens_used = state.get("tokens_used", 0)
+
+    try:
+        response = await llm.ainvoke([
+            SystemMessage(content=system_prompt),
+            HumanMessage(content=task_description),
+        ])
+        raw = _extract_text_content(response.content)
+        decomp_data = _extract_json(raw)
+        decomposition = TaskDecomposition(**decomp_data)
+        tokens_used += _extract_token_count(response)
+    except (json.JSONDecodeError, Exception) as e:
+        trace.append(f"decompose_task: LLM decomposition failed ({e}), falling back to single blueprint")
+        logger.warning("[DECOMPOSE] Decomposition failed: %s, falling back", e)
+        return {"decomposition": None, "current_subtask_index": 0, "completed_subtasks": [], "trace": trace, "tokens_used": tokens_used}
+
+    # Validate: check for overlapping target_files across sub-tasks
+    all_files: list[str] = []
+    has_overlap = False
+    for st in decomposition.sub_tasks:
+        for f in st.target_files:
+            if f in all_files:
+                has_overlap = True
+                break
+            all_files.append(f)
+        if has_overlap:
+            break
+
+    if has_overlap:
+        trace.append("decompose_task: overlapping target_files detected, falling back to single blueprint")
+        logger.warning("[DECOMPOSE] Sub-tasks have overlapping files, falling back to single blueprint")
+        return {"decomposition": None, "current_subtask_index": 0, "completed_subtasks": [], "trace": trace, "tokens_used": tokens_used}
+
+    trace.append(f"decompose_task: created {len(decomposition.sub_tasks)} sub-tasks")
+    logger.info("[DECOMPOSE] Created %d sub-tasks: %s", len(decomposition.sub_tasks), [st.description for st in decomposition.sub_tasks])
+
+    return {
+        "decomposition": decomposition,
+        "current_subtask_index": 0,
+        "completed_subtasks": [],
+        "tokens_used": tokens_used,
+        "trace": trace,
+    }
+
+
 # -- Node Functions --
 # CRITICAL: All graph nodes MUST be async def on Python 3.13+.
 # Sync nodes cause "generator didn't stop after throw()" under astream().
@@ -699,7 +826,27 @@ Respond with ONLY a valid JSON object matching this schema:
 }}
 
 Do not include any text before or after the JSON.{memory_block}{source_block}"""
-    user_msg = state.get("task_description", "")
+    # Issue #58: scope architect to current sub-task when decomposed
+    decomposition = state.get("decomposition")
+    if decomposition is not None:
+        current_idx = state.get("current_subtask_index", 0)
+        current_sub = decomposition.sub_tasks[current_idx]
+        user_msg = (
+            f"## Sub-Task {current_idx + 1}/{len(decomposition.sub_tasks)}: {current_sub.description}\n\n"
+            f"{current_sub.instructions}\n\n"
+            f"Target files: {', '.join(current_sub.target_files)}\n\n"
+            f"Overall task: {state.get('task_description', '')}"
+        )
+        completed = state.get("completed_subtasks", [])
+        if completed:
+            completed_block = "\n".join(
+                f"- Sub-task {i + 1}: {c['description']} (PASSED, files: {', '.join(c['blueprint']['target_files']) if c.get('blueprint') else 'n/a'})"
+                for i, c in enumerate(completed)
+            )
+            system_prompt += f"\n\n## Previously Completed Sub-Tasks\n{completed_block}"
+        trace.append(f"architect: scoped to sub-task {current_idx + 1}/{len(decomposition.sub_tasks)}: {current_sub.description}")
+    else:
+        user_msg = state.get("task_description", "")
     failure_report = state.get("failure_report")
     if failure_report and failure_report.is_architectural:
         user_msg += "\n\nPREVIOUS ATTEMPT FAILED (architectural issue):\n"
@@ -1294,6 +1441,63 @@ async def publish_code_node(state: GraphState) -> dict:
     return await _publish_code_async(state)
 
 
+async def advance_subtask_node(state: GraphState) -> dict:
+    """Snapshot completed sub-task and reset per-sub-task state (Issue #58).
+
+    Only meaningful when decomposition is active. For simple tasks,
+    this is a pass-through so route_next_subtask sends it to flush_memory.
+    """
+    trace = list(state.get("trace", []))
+    decomposition = state.get("decomposition")
+    if decomposition is None:
+        trace.append("advance_subtask: no decomposition, pass-through")
+        return {"trace": trace}
+
+    current_idx = state.get("current_subtask_index", 0)
+    sub_tasks = decomposition.sub_tasks
+    current_sub = sub_tasks[current_idx] if current_idx < len(sub_tasks) else None
+
+    completed = list(state.get("completed_subtasks", []))
+    if current_sub:
+        blueprint = state.get("blueprint")
+        completed.append({
+            "sub_task_id": current_sub.sub_task_id,
+            "status": "passed",
+            "blueprint": blueprint.model_dump() if blueprint else None,
+            "description": current_sub.description,
+        })
+
+    next_idx = current_idx + 1
+    trace.append(f"advance_subtask: completed sub-task {current_idx + 1}/{len(sub_tasks)}")
+    logger.info("[ADVANCE] Completed sub-task %d/%d", current_idx + 1, len(sub_tasks))
+
+    return {
+        "current_subtask_index": next_idx,
+        "completed_subtasks": completed,
+        "blueprint": None,
+        "generated_code": "",
+        "failure_report": None,
+        "retry_count": 0,
+        "parsed_files": [],
+        "sandbox_result": None,
+        "tool_calls_log": [],
+        "trace": trace,
+    }
+
+
+def route_next_subtask(state: GraphState) -> Literal["architect", "flush_memory"]:
+    """Route to next sub-task or finish (Issue #58)."""
+    decomposition = state.get("decomposition")
+    if decomposition is None:
+        return "flush_memory"
+    current_idx = state.get("current_subtask_index", 0)
+    if current_idx < len(decomposition.sub_tasks):
+        logger.info("[ROUTER] Advancing to sub-task %d/%d", current_idx + 1, len(decomposition.sub_tasks))
+        return "architect"
+    logger.info("[ROUTER] All %d sub-tasks complete", len(decomposition.sub_tasks))
+    return "flush_memory"
+
+
 def route_after_qa(state: GraphState) -> Literal["publish_code", "flush_memory", "developer", "architect", "__end__"]:
     status = state.get("status", WorkflowStatus.FAILED)
     retry_count = state.get("retry_count", 0)
@@ -1315,21 +1519,25 @@ def route_after_qa(state: GraphState) -> Literal["publish_code", "flush_memory",
 def build_graph() -> StateGraph:
     graph = StateGraph(GraphState)
     graph.add_node("gather_context", gather_context_node)
+    graph.add_node("decompose_task", decompose_task_node)
     graph.add_node("architect", architect_node)
     graph.add_node("developer", developer_node)
     graph.add_node("apply_code", apply_code_node)
     graph.add_node("sandbox_validate", sandbox_validate_node)
     graph.add_node("qa", qa_node)
     graph.add_node("publish_code", publish_code_node)
+    graph.add_node("advance_subtask", advance_subtask_node)
     graph.add_node("flush_memory", flush_memory_node)
     graph.add_edge(START, "gather_context")
-    graph.add_edge("gather_context", "architect")
+    graph.add_edge("gather_context", "decompose_task")
+    graph.add_edge("decompose_task", "architect")
     graph.add_edge("architect", "developer")
     graph.add_edge("developer", "apply_code")
     graph.add_edge("apply_code", "sandbox_validate")
     graph.add_edge("sandbox_validate", "qa")
     graph.add_conditional_edges("qa", route_after_qa)
-    graph.add_edge("publish_code", "flush_memory")
+    graph.add_edge("publish_code", "advance_subtask")
+    graph.add_conditional_edges("advance_subtask", route_next_subtask)
     graph.add_edge("flush_memory", END)
     return graph
 
@@ -1372,8 +1580,8 @@ def run_task(task_description, enable_tracing=True, session_id=None, tags=None):
     workflow = create_workflow()
     tools_config = init_tools_config()
     create_pr = bool(os.getenv("GITHUB_TOKEN"))
-    initial_state: GraphState = {"task_description": task_description, "blueprint": None, "generated_code": "", "failure_report": None, "status": WorkflowStatus.PLANNING, "retry_count": 0, "tokens_used": 0, "error_message": "", "memory_context": [], "memory_writes": [], "trace": [], "sandbox_result": None, "parsed_files": [], "tool_calls_log": [], "create_pr": create_pr, "workspace_type": "local"}
-    invoke_config = {"recursion_limit": 25, **tools_config}
+    initial_state: GraphState = {"task_description": task_description, "blueprint": None, "generated_code": "", "failure_report": None, "status": WorkflowStatus.PLANNING, "retry_count": 0, "tokens_used": 0, "error_message": "", "memory_context": [], "memory_writes": [], "trace": [], "sandbox_result": None, "parsed_files": [], "tool_calls_log": [], "create_pr": create_pr, "workspace_type": "local", "decomposition": None, "current_subtask_index": 0, "completed_subtasks": []}
+    invoke_config = {"recursion_limit": 50, **tools_config}
     if trace_config.callbacks:
         invoke_config["callbacks"] = trace_config.callbacks
     with trace_config.propagation_context():

--- a/dev-suite/tests/test_decomposition.py
+++ b/dev-suite/tests/test_decomposition.py
@@ -1,0 +1,431 @@
+"""Tests for multi-file task decomposition (Issue #58).
+
+Unit tests for the decomposition threshold logic, decompose_task_node,
+advance_subtask_node, route_next_subtask, and architect sub-task scoping.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.agents.architect import Blueprint, SubTask, TaskDecomposition
+from src.orchestrator import (
+    DECOMPOSE_FILE_THRESHOLD,
+    GraphState,
+    _needs_decomposition,
+    advance_subtask_node,
+    build_graph,
+    create_workflow,
+    decompose_task_node,
+    route_next_subtask,
+)
+
+# -- Model Tests --
+
+
+class TestSubTaskModel:
+    def test_subtask_creation(self):
+        st = SubTask(
+            sub_task_id="task-1-1",
+            parent_task_id="task-1",
+            sequence=0,
+            depends_on=[],
+            target_files=["src/models.py"],
+            instructions="Create data models",
+            description="Add data models",
+        )
+        assert st.sub_task_id == "task-1-1"
+        assert st.sequence == 0
+        assert st.depends_on == []
+
+    def test_subtask_with_dependencies(self):
+        st = SubTask(
+            sub_task_id="task-1-2",
+            parent_task_id="task-1",
+            sequence=1,
+            depends_on=["task-1-1"],
+            target_files=["src/api.py"],
+            instructions="Create API endpoints using models from sub-task 1",
+            description="Add API endpoints",
+        )
+        assert st.depends_on == ["task-1-1"]
+
+
+class TestTaskDecompositionModel:
+    def test_decomposition_creation(self):
+        decomp = TaskDecomposition(
+            parent_task_id="task-1",
+            sub_tasks=[
+                SubTask(
+                    sub_task_id="task-1-1",
+                    parent_task_id="task-1",
+                    sequence=0,
+                    target_files=["src/models.py", "src/schema.py"],
+                    instructions="Create data models",
+                    description="Add data models",
+                ),
+                SubTask(
+                    sub_task_id="task-1-2",
+                    parent_task_id="task-1",
+                    sequence=1,
+                    depends_on=["task-1-1"],
+                    target_files=["src/api.py", "src/routes.py"],
+                    instructions="Create API routes",
+                    description="Add API routes",
+                ),
+            ],
+            rationale="Separate models from API layer for independent testing",
+        )
+        assert len(decomp.sub_tasks) == 2
+        assert decomp.rationale != ""
+
+    def test_decomposition_json_roundtrip(self):
+        decomp = TaskDecomposition(
+            parent_task_id="task-1",
+            sub_tasks=[
+                SubTask(
+                    sub_task_id="task-1-1",
+                    parent_task_id="task-1",
+                    sequence=0,
+                    target_files=["a.py"],
+                    instructions="Do thing",
+                    description="Thing",
+                ),
+            ],
+            rationale="Single sub-task",
+        )
+        data = json.loads(decomp.model_dump_json())
+        roundtripped = TaskDecomposition(**data)
+        assert roundtripped.sub_tasks[0].sub_task_id == "task-1-1"
+
+
+# -- Threshold Detection Tests --
+
+
+class TestNeedsDecomposition:
+    def test_none_context_returns_false(self):
+        assert _needs_decomposition("some task", None) is False
+
+    def test_empty_context_returns_false(self):
+        assert _needs_decomposition("some task", []) is False
+
+    def test_below_file_threshold(self):
+        context = [{"path": f"src/file{i}.py"} for i in range(DECOMPOSE_FILE_THRESHOLD - 1)]
+        assert _needs_decomposition("some task", context) is False
+
+    def test_at_file_threshold(self):
+        context = [{"path": f"src/file{i}.py"} for i in range(DECOMPOSE_FILE_THRESHOLD)]
+        assert _needs_decomposition("some task", context) is True
+
+    def test_above_file_threshold(self):
+        context = [{"path": f"src/file{i}.py"} for i in range(DECOMPOSE_FILE_THRESHOLD + 2)]
+        assert _needs_decomposition("some task", context) is True
+
+    def test_below_dir_threshold_single_dir(self):
+        context = [
+            {"path": "src/a.py"},
+            {"path": "src/b.py"},
+        ]
+        assert _needs_decomposition("some task", context) is False
+
+    def test_at_dir_threshold(self):
+        context = [
+            {"path": "src/a.py"},
+            {"path": "tests/test_a.py"},
+        ]
+        assert _needs_decomposition("some task", context) is True
+
+    def test_files_without_dirs_not_counted(self):
+        """Top-level files (no slash) don't count toward directory threshold."""
+        context = [
+            {"path": "setup.py"},
+            {"path": "README.md"},
+            {"path": "main.py"},
+        ]
+        assert _needs_decomposition("some task", context) is False
+
+    def test_mixed_dirs_and_files(self):
+        context = [
+            {"path": "src/models.py"},
+            {"path": "tests/test_models.py"},
+            {"path": "setup.py"},
+        ]
+        # 2 top-level dirs (src, tests) >= threshold
+        assert _needs_decomposition("some task", context) is True
+
+
+# -- Decompose Task Node Tests --
+
+
+SAMPLE_DECOMPOSITION = TaskDecomposition(
+    parent_task_id="decomp-1",
+    sub_tasks=[
+        SubTask(
+            sub_task_id="decomp-1-1",
+            parent_task_id="decomp-1",
+            sequence=0,
+            target_files=["src/models/user.py", "src/models/post.py"],
+            instructions="Create User and Post data models",
+            description="Add data models",
+        ),
+        SubTask(
+            sub_task_id="decomp-1-2",
+            parent_task_id="decomp-1",
+            sequence=1,
+            depends_on=["decomp-1-1"],
+            target_files=["src/api/users.py", "src/api/posts.py"],
+            instructions="Create REST endpoints for users and posts",
+            description="Add API endpoints",
+        ),
+        SubTask(
+            sub_task_id="decomp-1-3",
+            parent_task_id="decomp-1",
+            sequence=2,
+            depends_on=["decomp-1-1", "decomp-1-2"],
+            target_files=["tests/test_users.py", "tests/test_posts.py"],
+            instructions="Write integration tests",
+            description="Add integration tests",
+        ),
+    ],
+    rationale="Separate models, API, and tests for independent implementation",
+)
+
+
+def _make_llm_response(content: str, total_tokens: int = 500) -> MagicMock:
+    resp = MagicMock()
+    resp.content = content
+    resp.usage_metadata = {"total_tokens": total_tokens}
+    return resp
+
+
+class TestDecomposeTaskNode:
+    @pytest.fixture
+    def small_state(self) -> GraphState:
+        return {
+            "task_description": "Add a greet function",
+            "gathered_context": [
+                {"path": "src/utils.py", "content": "# utils"},
+                {"path": "src/main.py", "content": "# main"},
+            ],
+            "tokens_used": 0,
+            "trace": [],
+        }
+
+    @pytest.fixture
+    def large_state(self) -> GraphState:
+        return {
+            "task_description": "Implement full user management system",
+            "gathered_context": [
+                {"path": f"src/models/file{i}.py", "content": f"# file{i}"} for i in range(6)
+            ],
+            "tokens_used": 0,
+            "trace": [],
+        }
+
+    async def test_skips_small_task(self, small_state):
+        result = await decompose_task_node(small_state)
+        assert result["decomposition"] is None
+        assert result["current_subtask_index"] == 0
+        assert result["completed_subtasks"] == []
+        assert any("below threshold" in t for t in result["trace"])
+
+    @patch("src.orchestrator._get_architect_llm")
+    async def test_decomposes_large_task(self, mock_get_llm, large_state):
+        mock_llm = MagicMock()
+        mock_get_llm.return_value = mock_llm
+        mock_llm.ainvoke = AsyncMock(
+            return_value=_make_llm_response(SAMPLE_DECOMPOSITION.model_dump_json())
+        )
+
+        result = await decompose_task_node(large_state)
+        assert result["decomposition"] is not None
+        assert len(result["decomposition"].sub_tasks) == 3
+        assert result["current_subtask_index"] == 0
+        assert result["completed_subtasks"] == []
+
+    @patch("src.orchestrator._get_architect_llm")
+    async def test_fallback_on_llm_failure(self, mock_get_llm, large_state):
+        mock_llm = MagicMock()
+        mock_get_llm.return_value = mock_llm
+        mock_llm.ainvoke = AsyncMock(
+            return_value=_make_llm_response("not valid json at all")
+        )
+
+        result = await decompose_task_node(large_state)
+        assert result["decomposition"] is None
+        assert any("falling back" in t for t in result["trace"])
+
+    @patch("src.orchestrator._get_architect_llm")
+    async def test_fallback_on_overlapping_files(self, mock_get_llm, large_state):
+        """Sub-tasks with overlapping target_files fall back to single blueprint."""
+        overlapping = TaskDecomposition(
+            parent_task_id="overlap-1",
+            sub_tasks=[
+                SubTask(
+                    sub_task_id="o-1",
+                    parent_task_id="overlap-1",
+                    sequence=0,
+                    target_files=["src/shared.py", "src/a.py"],
+                    instructions="Do A",
+                    description="Task A",
+                ),
+                SubTask(
+                    sub_task_id="o-2",
+                    parent_task_id="overlap-1",
+                    sequence=1,
+                    target_files=["src/shared.py", "src/b.py"],  # overlaps with o-1
+                    instructions="Do B",
+                    description="Task B",
+                ),
+            ],
+            rationale="Test overlap",
+        )
+        mock_llm = MagicMock()
+        mock_get_llm.return_value = mock_llm
+        mock_llm.ainvoke = AsyncMock(
+            return_value=_make_llm_response(overlapping.model_dump_json())
+        )
+
+        result = await decompose_task_node(large_state)
+        assert result["decomposition"] is None
+        assert any("overlapping" in t for t in result["trace"])
+
+    @patch("src.orchestrator._get_architect_llm")
+    async def test_tokens_tracked(self, mock_get_llm, large_state):
+        mock_llm = MagicMock()
+        mock_get_llm.return_value = mock_llm
+        mock_llm.ainvoke = AsyncMock(
+            return_value=_make_llm_response(SAMPLE_DECOMPOSITION.model_dump_json(), total_tokens=750)
+        )
+        large_state["tokens_used"] = 100
+
+        result = await decompose_task_node(large_state)
+        assert result["tokens_used"] == 850  # 100 + 750
+
+
+# -- Advance Subtask Node Tests --
+
+
+class TestAdvanceSubtaskNode:
+    @pytest.fixture
+    def decomposed_state(self) -> GraphState:
+        bp = Blueprint(
+            task_id="decomp-1-1",
+            target_files=["src/models/user.py"],
+            instructions="Create User model",
+            constraints=["Use Pydantic"],
+            acceptance_criteria=["Model validates correctly"],
+        )
+        return {
+            "decomposition": SAMPLE_DECOMPOSITION,
+            "current_subtask_index": 0,
+            "completed_subtasks": [],
+            "blueprint": bp,
+            "generated_code": "class User: pass",
+            "failure_report": None,
+            "retry_count": 1,
+            "parsed_files": [{"path": "src/models/user.py", "content": "class User: pass"}],
+            "sandbox_result": None,
+            "tool_calls_log": [{"tool": "write"}],
+            "trace": [],
+            "tokens_used": 1000,
+            "memory_writes": [{"content": "User model", "tier": "l1"}],
+        }
+
+    async def test_snapshots_completed_subtask(self, decomposed_state):
+        result = await advance_subtask_node(decomposed_state)
+        assert len(result["completed_subtasks"]) == 1
+        assert result["completed_subtasks"][0]["sub_task_id"] == "decomp-1-1"
+        assert result["completed_subtasks"][0]["status"] == "passed"
+
+    async def test_increments_index(self, decomposed_state):
+        result = await advance_subtask_node(decomposed_state)
+        assert result["current_subtask_index"] == 1
+
+    async def test_resets_per_subtask_state(self, decomposed_state):
+        result = await advance_subtask_node(decomposed_state)
+        assert result["blueprint"] is None
+        assert result["generated_code"] == ""
+        assert result["failure_report"] is None
+        assert result["retry_count"] == 0
+        assert result["parsed_files"] == []
+        assert result["sandbox_result"] is None
+        assert result["tool_calls_log"] == []
+
+    async def test_passthrough_without_decomposition(self):
+        state: GraphState = {
+            "decomposition": None,
+            "trace": [],
+        }
+        result = await advance_subtask_node(state)
+        assert "pass-through" in result["trace"][-1]
+
+    async def test_accumulates_completed_subtasks(self):
+        """Second sub-task completion appends to existing list."""
+        bp = Blueprint(
+            task_id="decomp-1-2",
+            target_files=["src/api/users.py"],
+            instructions="Create API",
+            constraints=[],
+            acceptance_criteria=["API works"],
+        )
+        state: GraphState = {
+            "decomposition": SAMPLE_DECOMPOSITION,
+            "current_subtask_index": 1,
+            "completed_subtasks": [
+                {"sub_task_id": "decomp-1-1", "status": "passed", "blueprint": None, "description": "Add data models"},
+            ],
+            "blueprint": bp,
+            "trace": [],
+        }
+        result = await advance_subtask_node(state)
+        assert len(result["completed_subtasks"]) == 2
+        assert result["completed_subtasks"][1]["sub_task_id"] == "decomp-1-2"
+        assert result["current_subtask_index"] == 2
+
+
+# -- Route Next Subtask Tests --
+
+
+class TestRouteNextSubtask:
+    def test_no_decomposition_goes_to_flush(self):
+        state: GraphState = {"decomposition": None, "current_subtask_index": 0}
+        assert route_next_subtask(state) == "flush_memory"
+
+    def test_more_subtasks_goes_to_architect(self):
+        state: GraphState = {
+            "decomposition": SAMPLE_DECOMPOSITION,
+            "current_subtask_index": 1,  # sub-task 2 of 3
+        }
+        assert route_next_subtask(state) == "architect"
+
+    def test_all_subtasks_done_goes_to_flush(self):
+        state: GraphState = {
+            "decomposition": SAMPLE_DECOMPOSITION,
+            "current_subtask_index": 3,  # all 3 done
+        }
+        assert route_next_subtask(state) == "flush_memory"
+
+    def test_last_subtask_goes_to_flush(self):
+        state: GraphState = {
+            "decomposition": SAMPLE_DECOMPOSITION,
+            "current_subtask_index": len(SAMPLE_DECOMPOSITION.sub_tasks),
+        }
+        assert route_next_subtask(state) == "flush_memory"
+
+
+# -- Graph Structure Tests --
+
+
+class TestDecompositionGraphStructure:
+    def test_graph_has_decomposition_nodes(self):
+        graph = build_graph()
+        compiled = graph.compile()
+        node_names = set(compiled.get_graph().nodes.keys())
+        assert "decompose_task" in node_names
+        assert "advance_subtask" in node_names
+
+    def test_graph_compiles_with_new_nodes(self):
+        workflow = create_workflow()
+        assert workflow is not None

--- a/dev-suite/tests/test_e2e.py
+++ b/dev-suite/tests/test_e2e.py
@@ -18,7 +18,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from src.agents.architect import Blueprint
+from src.agents.architect import Blueprint, SubTask, TaskDecomposition
 from src.agents.qa import FailureReport
 from src.memory.chroma_store import ChromaMemoryStore
 from src.orchestrator import (
@@ -410,3 +410,231 @@ class TestE2ETracingIntegration:
         mock_qa_llm.return_value.ainvoke = AsyncMock(return_value=_make_llm_response(SAMPLE_QA_PASS.model_dump_json()))
         result = run_task("Create email validator", enable_tracing=True)
         mock_trace.assert_called_once()
+
+
+# -- Decomposition E2E Tests (Issue #58) --
+
+
+DECOMPOSITION_RESPONSE = TaskDecomposition(
+    parent_task_id="decomp-e2e",
+    sub_tasks=[
+        SubTask(
+            sub_task_id="decomp-e2e-1",
+            parent_task_id="decomp-e2e",
+            sequence=0,
+            target_files=["src/models/user.py", "src/models/post.py"],
+            instructions="Create User and Post data models with Pydantic",
+            description="Add data models",
+        ),
+        SubTask(
+            sub_task_id="decomp-e2e-2",
+            parent_task_id="decomp-e2e",
+            sequence=1,
+            depends_on=["decomp-e2e-1"],
+            target_files=["src/api/users.py", "src/api/posts.py"],
+            instructions="Create REST API endpoints for users and posts",
+            description="Add API endpoints",
+        ),
+    ],
+    rationale="Separate models from API for independent testing",
+)
+
+BLUEPRINT_SUB1 = Blueprint(
+    task_id="decomp-e2e-1",
+    target_files=["src/models/user.py", "src/models/post.py"],
+    instructions="Create User and Post data models",
+    constraints=["Use Pydantic"],
+    acceptance_criteria=["Models validate correctly"],
+)
+
+BLUEPRINT_SUB2 = Blueprint(
+    task_id="decomp-e2e-2",
+    target_files=["src/api/users.py", "src/api/posts.py"],
+    instructions="Create REST API endpoints",
+    constraints=["Use FastAPI"],
+    acceptance_criteria=["Endpoints return 200"],
+)
+
+CODE_SUB1 = '''# --- FILE: src/models/user.py ---
+from pydantic import BaseModel
+
+class User(BaseModel):
+    name: str
+    email: str
+
+# --- FILE: src/models/post.py ---
+from pydantic import BaseModel
+
+class Post(BaseModel):
+    title: str
+    body: str
+'''
+
+CODE_SUB2 = '''# --- FILE: src/api/users.py ---
+from fastapi import APIRouter
+router = APIRouter()
+
+@router.get("/users")
+def list_users():
+    return []
+
+# --- FILE: src/api/posts.py ---
+from fastapi import APIRouter
+router = APIRouter()
+
+@router.get("/posts")
+def list_posts():
+    return []
+'''
+
+QA_PASS_SUB1 = FailureReport(
+    task_id="decomp-e2e-1",
+    status="pass",
+    tests_passed=2,
+    tests_failed=0,
+    errors=[],
+    failed_files=[],
+    is_architectural=False,
+    recommendation="Models look good.",
+)
+
+QA_PASS_SUB2 = FailureReport(
+    task_id="decomp-e2e-2",
+    status="pass",
+    tests_passed=2,
+    tests_failed=0,
+    errors=[],
+    failed_files=[],
+    is_architectural=False,
+    recommendation="API endpoints work.",
+)
+
+
+class TestE2EDecomposition:
+    """E2E tests for multi-file task decomposition (Issue #58).
+
+    These mock a 6-file task that triggers decomposition into 2 sub-tasks,
+    each going through the full architect -> developer -> QA loop.
+    """
+
+    @patch("src.orchestrator._fetch_memory_context")
+    @patch("src.orchestrator._get_qa_llm")
+    @patch("src.orchestrator._get_developer_llm")
+    @patch("src.orchestrator._get_architect_llm")
+    def test_decomposed_pipeline_both_subtasks_pass(
+        self, mock_arch_llm, mock_dev_llm, mock_qa_llm, mock_memory
+    ):
+        """Full pipeline: decompose -> sub-task 1 pass -> sub-task 2 pass -> PASSED."""
+        mock_memory.return_value = []
+
+        # Architect LLM is called 3 times:
+        # 1) decompose_task_node (returns TaskDecomposition)
+        # 2) architect_node for sub-task 1 (returns Blueprint)
+        # 3) architect_node for sub-task 2 (returns Blueprint)
+        mock_arch_llm.return_value.ainvoke = AsyncMock(
+            side_effect=[
+                _make_llm_response(DECOMPOSITION_RESPONSE.model_dump_json(), total_tokens=600),
+                _make_llm_response(BLUEPRINT_SUB1.model_dump_json(), total_tokens=400),
+                _make_llm_response(BLUEPRINT_SUB2.model_dump_json(), total_tokens=400),
+            ]
+        )
+
+        # Developer called twice (once per sub-task)
+        mock_dev_llm.return_value.ainvoke = AsyncMock(
+            side_effect=[
+                _make_llm_response(CODE_SUB1, total_tokens=800),
+                _make_llm_response(CODE_SUB2, total_tokens=800),
+            ]
+        )
+
+        # QA called twice (once per sub-task, both pass)
+        mock_qa_llm.return_value.ainvoke = AsyncMock(
+            side_effect=[
+                _make_llm_response(QA_PASS_SUB1.model_dump_json(), total_tokens=300),
+                _make_llm_response(QA_PASS_SUB2.model_dump_json(), total_tokens=300),
+            ]
+        )
+
+        # Need gathered_context with 5+ files to trigger decomposition.
+        # Patch gather_context_node to return enough files.
+        large_context = [
+            {"path": f"src/models/file{i}.py", "content": f"# file{i}", "truncated": False}
+            for i in range(6)
+        ]
+        with patch("src.orchestrator.gather_context_node", new=AsyncMock(
+            return_value={"gathered_context": large_context, "trace": ["gather_context: 6 files"]}
+        )):
+            result = run_task(
+                "Build a user management system with models and API endpoints",
+                enable_tracing=False,
+            )
+
+        assert result.status == WorkflowStatus.PASSED
+        assert result.decomposition is not None
+        assert len(result.decomposition.sub_tasks) == 2
+        assert len(result.completed_subtasks) == 2
+        assert result.completed_subtasks[0]["sub_task_id"] == "decomp-e2e-1"
+        assert result.completed_subtasks[1]["sub_task_id"] == "decomp-e2e-2"
+        # Tokens: 600 (decomp) + 400+800+300 (sub1) + 400+800+300 (sub2) = 3600
+        assert result.tokens_used == 3600
+        assert mock_arch_llm.return_value.ainvoke.call_count == 3
+        assert mock_dev_llm.return_value.ainvoke.call_count == 2
+        assert mock_qa_llm.return_value.ainvoke.call_count == 2
+
+    @patch("src.orchestrator._fetch_memory_context")
+    @patch("src.orchestrator._get_qa_llm")
+    @patch("src.orchestrator._get_developer_llm")
+    @patch("src.orchestrator._get_architect_llm")
+    def test_decomposed_pipeline_subtask_failure_skips_remaining(
+        self, mock_arch_llm, mock_dev_llm, mock_qa_llm, mock_memory
+    ):
+        """Sub-task 1 fails after max retries -> remaining sub-tasks skipped."""
+        mock_memory.return_value = []
+
+        mock_arch_llm.return_value.ainvoke = AsyncMock(
+            side_effect=[
+                _make_llm_response(DECOMPOSITION_RESPONSE.model_dump_json(), total_tokens=600),
+                _make_llm_response(BLUEPRINT_SUB1.model_dump_json(), total_tokens=400),
+            ]
+        )
+
+        # Developer produces code each time
+        mock_dev_llm.return_value.ainvoke = AsyncMock(
+            return_value=_make_llm_response(CODE_SUB1, total_tokens=800)
+        )
+
+        # QA always fails for sub-task 1 (triggers max retries -> flush_memory -> END)
+        qa_fail = FailureReport(
+            task_id="decomp-e2e-1",
+            status="fail",
+            tests_passed=0,
+            tests_failed=2,
+            errors=["Test failure"],
+            failed_files=["src/models/user.py"],
+            is_architectural=False,
+            recommendation="Fix the models.",
+        )
+        mock_qa_llm.return_value.ainvoke = AsyncMock(
+            return_value=_make_llm_response(qa_fail.model_dump_json(), total_tokens=300)
+        )
+
+        large_context = [
+            {"path": f"src/models/file{i}.py", "content": f"# file{i}", "truncated": False}
+            for i in range(6)
+        ]
+        with patch("src.orchestrator.gather_context_node", new=AsyncMock(
+            return_value={"gathered_context": large_context, "trace": ["gather_context: 6 files"]}
+        )):
+            result = run_task(
+                "Build a user management system",
+                enable_tracing=False,
+            )
+
+        # Sub-task 1 failed after retries, sub-task 2 was never attempted
+        assert result.status != WorkflowStatus.PASSED
+        assert result.decomposition is not None
+        assert len(result.completed_subtasks) == 0  # no sub-task passed
+        # Developer was called multiple times (initial + retries for sub-task 1)
+        assert mock_dev_llm.return_value.ainvoke.call_count >= 2
+        # Sub-task 2 architect was never called (only decomp + sub-task 1 blueprint)
+        assert mock_arch_llm.return_value.ainvoke.call_count == 2


### PR DESCRIPTION
## Summary
- Adds `decompose_task` node that detects large-scope tasks (5+ files or 2+ top-level dirs) and splits them into ordered sub-tasks via LLM
- Each sub-task cycles through the full architect → developer → QA loop independently, with state reset between sub-tasks
- Small tasks pass through unchanged — zero impact on existing single-Blueprint path
- Graceful fallback to single Blueprint on LLM failure or overlapping target files

## Details
- New models: `SubTask`, `TaskDecomposition` in `agents/architect.py`
- New graph nodes: `decompose_task`, `advance_subtask` with `route_next_subtask` conditional routing
- `architect_node` scoped to current sub-task instructions when decomposition active
- Completed sub-task context injected into architect prompt for later sub-tasks
- Recursion limit increased from 25 to 50 to support multi-sub-task loops

## Test plan
- [x] 29 new unit tests in `test_decomposition.py` (models, threshold logic, nodes, routing, graph structure)
- [x] 2 new E2E tests: happy path (both sub-tasks pass) and failure path (sub-task fails, remaining skipped)
- [x] All 968 existing tests pass unchanged
- [x] Ruff lint clean

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)