### PR TITLE
fix: add workspace field to smoke-test.sh task submission

### DIFF
--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -161,8 +161,40 @@ echo ""
 
 CANONICAL_PROMPT='Create a Python function called greet in a new file greet.py that takes a name parameter and returns a greeting string'
 
+# Issue #105: POST /tasks requires `workspace` when workspace_type is 'local'.
+# Fetch the default workspace from GET /workspaces rather than assuming.
+DEFAULT_WS=$(curl_get "$API_URL/workspaces" 2>/dev/null | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    for w in d.get('data', []):
+        if w.get('is_default'):
+            print(w['path'])
+            break
+except Exception:
+    pass
+" 2>/dev/null || echo "")
+
+if [ -z "$DEFAULT_WS" ]; then
+    echo -e "  ${RED}FAILED${NC} -- GET /workspaces returned no default workspace"
+    exit 1
+fi
+
+printf "  ${DIM}Workspace: %s${NC}\n" "$DEFAULT_WS"
+
+# Build the request body via python3 so Windows paths (backslashes) are
+# escaped correctly as JSON -- inline shell interpolation mangles them.
+TASK_BODY=$(python3 -c "
+import json, sys
+print(json.dumps({
+    'description': sys.argv[1],
+    'create_pr': False,
+    'workspace': sys.argv[2],
+}))
+" "$CANONICAL_PROMPT" "$DEFAULT_WS")
+
 echo -e "  Submitting canonical test prompt..."
-TASK_RESPONSE=$(curl_post "$API_URL/tasks" "{\"description\": \"$CANONICAL_PROMPT\", \"create_pr\": false}" 2>/dev/null || echo "")
+TASK_RESPONSE=$(curl_post "$API_URL/tasks" "$TASK_BODY" 2>/dev/null || echo "")
 
 if [ -z "$TASK_RESPONSE" ]; then
     echo -e "  ${RED}FAILED${NC} -- POST /tasks returned empty response"


### PR DESCRIPTION
## Summary

- \`scripts/smoke-test.sh\` has been broken since issue #105 (workspace security model) made \`workspace\` required on \`POST /tasks\` when \`workspace_type='local'\`. Last commit to the script was \`75bca92\` (#173), before #105 landed.
- Fetch the default workspace from \`GET /workspaces\` at runtime and build the request body via \`python3 -c\` so Windows paths escape correctly as JSON.
- Swap \`echo -e\` -> \`printf\` on the Workspace display line so backslashes in the path (\`\a\`, \`\b\`) aren't interpreted as control chars.

## Why now

Surfaced while validating the #179 self-dev surgical-edit fixes. I ran \`bash scripts/smoke-test.sh\` as a regression check and it couldn't even submit the canonical greet.py prompt:

\`\`\`
{"detail":[{"type":"value_error","loc":["body"],"msg":"Value error, workspace is required when workspace_type is 'local'.", ...}]}
\`\`\`

## Test plan

- [x] \`bash scripts/smoke-test.sh --dry-run\` -- stages 0-1 pass
- [x] \`bash scripts/smoke-test.sh\` (full run) -- passed all three stages in 33s (task-d45410aa, \$0.14, 0 retries)
- [x] PR title / branch conventions unchanged

Refs #105, #173.

🤖 Generated with [Claude Code](https://claude.com/claude-code)