### PR TITLE
fix(api): load_dotenv override=True so .env beats stale shell env

### DIFF
--- a/dev-suite/src/api/main.py
+++ b/dev-suite/src/api/main.py
@@ -65,7 +65,10 @@ from .models import (
 )
 from .state import state_manager
 
-load_dotenv()
+# override=True so .env beats any stale value pre-set in the parent shell
+# (common failure mode: a prior key cached in a Windows User env var silently
+# overrides .env and produces opaque 401s).
+load_dotenv(override=True)
 
 logger = logging.getLogger(__name__)
 

--- a/dev-suite/src/api/state.py
+++ b/dev-suite/src/api/state.py
@@ -34,7 +34,8 @@ from datetime import datetime, timezone
 # This was the root cause of the WORKSPACE_ROOT=dev-suite bug.
 from dotenv import load_dotenv
 
-load_dotenv()
+# override=True so .env beats any stale value pre-set in the parent shell.
+load_dotenv(override=True)
 
 from ..workspace import WorkspaceManager
 from .events import EventType, SSEEvent, event_bus


### PR DESCRIPTION
## Summary

Change \`load_dotenv()\` -> \`load_dotenv(override=True)\` in \`dev-suite/src/api/main.py\` (line 68) and \`dev-suite/src/api/state.py\` (line 37). Makes \`.env\` authoritative for secrets instead of silently losing to a stale value in the parent shell's environment.

## Why

Surfaced while validating #179 via the smoke test. Backend kept 401'ing on Anthropic (\"invalid x-api-key\") even after restarts. Root cause:

1. A stale \`ANTHROPIC_API_KEY\` lived in the Windows User-scope env var (from an old \`setx\`)
2. Every VS Code terminal inherited it from VS Code's parent process env
3. The FastAPI backend inherited that stale value into its process env
4. \`load_dotenv()\` with default \`override=False\` saw the env already set and skipped \`.env\` (which had the current rotated key)
5. Every LLM call to Anthropic failed with an opaque 401

Survived backend restarts because VS Code's own cached parent env kept the stale value. The only way to fix it without this patch is: close VS Code -> delete the User env var -> reopen VS Code. That's a terrible developer experience for a silently-wrong config.

With \`override=True\`, \`.env\` wins. If the developer wants to override .env via shell, they can unset-then-export explicitly -- that's the safer failure mode.

## Test plan

- [x] Backend reloads cleanly with the patch (no import errors)
- [x] \`curl /health\` returns 200 after reload
- [x] \`bash scripts/smoke-test.sh\` passes all three stages end-to-end with a stale \`ANTHROPIC_API_KEY\` in the parent shell (task-d45410aa, \$0.14, passed in 33s)
- [x] Existing 953+ test suite still green (no regressions)

## Related

Depends-on: nothing.
Related-to: the self-dev readiness validation work for #179. The smoke-test.sh fix in #183 exposed this issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)