### PR TITLE
fix(agents): FailureReport None-tolerance on optional fields

### DIFF
--- a/dev-suite/src/agents/qa.py
+++ b/dev-suite/src/agents/qa.py
@@ -78,6 +78,35 @@ class FailureReport(BaseModel):
     fix_complexity: FixComplexity | None = None
     exact_fix_hint: str | None = None
 
+    @field_validator(
+        "recommendation", mode="before"
+    )
+    @classmethod
+    def _coerce_recommendation_none(cls, v: object) -> object:
+        """Coerce None to "" so a passing QA review (recommendation=null)
+        doesn't crash FailureReport validation."""
+        return "" if v is None else v
+
+    @field_validator("errors", "failed_files", mode="before")
+    @classmethod
+    def _coerce_list_none(cls, v: object) -> object:
+        """Coerce None to [] for list fields.
+
+        LLMs may emit `"errors": null` / `"failed_files": null` when
+        there are no items; treat as the empty-list default rather
+        than crashing.
+        """
+        return [] if v is None else v
+
+    @field_validator(
+        "tests_passed", "tests_failed", mode="before"
+    )
+    @classmethod
+    def _coerce_count_none(cls, v: object) -> object:
+        """Coerce None to 0 for test-count fields (happens on reviews
+        that have no test execution context)."""
+        return 0 if v is None else v
+
     @field_validator("failure_type", mode="before")
     @classmethod
     def normalize_failure_type(cls, v: object) -> object:

--- a/dev-suite/tests/test_qa_escalation.py
+++ b/dev-suite/tests/test_qa_escalation.py
@@ -201,6 +201,89 @@ class TestFailureReportEscalation:
 
 
 # ---------------------------------------------------------------------------
+# None-tolerance for LLM output (Layer B gate-test finding)
+# ---------------------------------------------------------------------------
+
+
+class TestFailureReportNoneTolerance:
+    """Layer B gate test crashed after 173s / $1.20 on:
+
+        Input should be a valid string [type=string_type, input_value=None]
+
+    because the QA LLM returned {"recommendation": null, ...} on a
+    passing review. The FailureReport model's docstring already
+    promises defensive defaults against LLM-emitted nulls, but this
+    field (and a few others) were missed. These tests pin the
+    None-tolerance contract so future LLM output variants don't
+    crash the orchestrator mid-retry.
+    """
+
+    def _minimal(self, **overrides):
+        data = {"task_id": "test-task", "status": "pass"}
+        data.update(overrides)
+        return FailureReport(**data)
+
+    def test_recommendation_null_coerces_to_empty_string(self):
+        r = self._minimal(recommendation=None)
+        assert r.recommendation == ""
+
+    def test_errors_null_coerces_to_empty_list(self):
+        r = self._minimal(errors=None)
+        assert r.errors == []
+
+    def test_failed_files_null_coerces_to_empty_list(self):
+        r = self._minimal(failed_files=None)
+        assert r.failed_files == []
+
+    def test_tests_passed_null_coerces_to_zero(self):
+        r = self._minimal(tests_passed=None)
+        assert r.tests_passed == 0
+
+    def test_tests_failed_null_coerces_to_zero(self):
+        r = self._minimal(tests_failed=None)
+        assert r.tests_failed == 0
+
+    def test_full_null_output_constructs_cleanly(self):
+        """Reproduces the Layer B QA output: every optional field null."""
+        r = FailureReport(
+            task_id="fix-113-resize-cap",
+            status="pass",
+            tests_passed=None,
+            tests_failed=None,
+            errors=None,
+            failed_files=None,
+            recommendation=None,
+            failure_type=None,
+            fix_complexity=None,
+            exact_fix_hint=None,
+        )
+        assert r.recommendation == ""
+        assert r.errors == []
+        assert r.failed_files == []
+        assert r.tests_passed == 0
+        assert r.tests_failed == 0
+        assert r.exact_fix_hint is None  # str | None already
+        assert r.failure_type is None
+        assert r.fix_complexity is None
+
+    def test_valid_values_still_round_trip(self):
+        """Defensive coercion doesn't clobber legitimate non-null values."""
+        r = self._minimal(
+            status="fail",
+            recommendation="Use filesystem_patch",
+            errors=["off-by-one"],
+            failed_files=["BottomPanel.svelte"],
+            tests_passed=5,
+            tests_failed=1,
+        )
+        assert r.recommendation == "Use filesystem_patch"
+        assert r.errors == ["off-by-one"]
+        assert r.failed_files == ["BottomPanel.svelte"]
+        assert r.tests_passed == 5
+        assert r.tests_failed == 1
+
+
+# ---------------------------------------------------------------------------
 # Routing logic
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Add \`@field_validator(mode='before')\` coercion on \`FailureReport\` fields that already had \"defensive defaults\" promised in the model's docstring but weren't actually protected against LLM-emitted \`null\`:

- \`recommendation\` (str): None -> \"\"
- \`errors\` (list[str]): None -> []
- \`failed_files\` (list[str]): None -> []
- \`tests_passed\` (int): None -> 0
- \`tests_failed\` (int): None -> 0

## Why

Layer B gate test on #113 ran for 173s, consumed \$1.20 of LLM budget, and crashed at QA turn 15 of the retry with:

\`\`\`
QA failed to produce valid report: 1 validation error for FailureReport
recommendation
  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
\`\`\`

Claude Sonnet 4 returned \`{\"recommendation\": null, ...}\` on a passing review — perfectly reasonable LLM behavior (nothing to recommend when there's no failure). The pattern for accepting null on optional fields already exists in this file (see \`normalize_failure_type\`, \`normalize_fix_complexity\`). This PR extends it to the remaining fields.

## Test plan

- [x] New \`TestFailureReportNoneTolerance\` in \`tests/test_qa_escalation.py\` — 7 tests covering each field individually, the full-null reproduction of the exact Layer B crash, and a regression guard that legitimate non-null values still round-trip.
- [x] \`cd dev-suite && uv run --group api pytest tests/test_qa_escalation.py -v\` — 43/43 pass.
- [x] Full suite still green.

## Related

Discovered during #179 Layer B gate-test rerun. Independent of the other finding (tool provider cross-directory gap) which will land separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)