### PR TITLE
fix(tools): cross-directory resolution for LocalToolProvider (closes #180's Fix 1 gap)

### DIFF
--- a/dev-suite/src/tools/provider.py
+++ b/dev-suite/src/tools/provider.py
@@ -134,18 +134,79 @@ class ToolProvider(ABC):
 # -- Path Validation --
 
 
-def _validate_path(requested: str, workspace_root: Path) -> Path:
-    """Validate that a path is within the workspace root.
+def _find_repo_root(start: Path) -> Path:
+    """Walk parent directories looking for a ``.git`` entry.
 
-    Resolves symlinks and relative paths, then checks containment.
-    Raises PathValidationError if the path escapes the workspace.
+    Returns the first ancestor containing ``.git``, or ``start`` itself
+    if none is found. Mirrors the helper in ``orchestrator.py`` so tool
+    handlers can reach sibling directories (e.g., ``dashboard/`` when
+    the workspace is ``dev-suite/``) just like ``gather_context_node``
+    already does for reads.
     """
-    resolved = (workspace_root / requested).resolve()
+    start = start.resolve()
+    for candidate in (start, *start.parents):
+        if (candidate / ".git").exists():
+            return candidate
+    return start
 
-    if not str(resolved).startswith(str(workspace_root.resolve())):
+
+def _resolve_path_smart(
+    requested: str,
+    workspace_root: Path,
+    allowed_root: Path,
+) -> Path:
+    """Resolve ``requested`` against workspace or repo root.
+
+    Prefers workspace-relative resolution (existing behavior). Falls
+    back to repo-relative when the first path segment names a
+    top-level directory that exists in the repo but not the workspace
+    -- e.g., ``dashboard/...`` when the workspace is ``dev-suite/`` in
+    a monorepo.
+
+    This lets self-dev agents edit any file in the repo via the
+    obvious relative path without needing a ``../`` dance.
+    """
+    workspace_root = workspace_root.resolve()
+    allowed_root = allowed_root.resolve()
+
+    # No ambiguity when the two are the same.
+    if workspace_root == allowed_root:
+        return (workspace_root / requested).resolve()
+
+    parts = Path(requested).parts
+    if parts:
+        first_segment = parts[0]
+        in_workspace = (workspace_root / first_segment).exists()
+        in_repo = (allowed_root / first_segment).exists()
+        if not in_workspace and in_repo:
+            return (allowed_root / requested).resolve()
+
+    return (workspace_root / requested).resolve()
+
+
+def _validate_path(
+    requested: str,
+    workspace_root: Path,
+    allowed_root: Path | None = None,
+) -> Path:
+    """Validate that a path is within the allowed root.
+
+    ``allowed_root`` defines the security boundary (defaults to
+    ``workspace_root`` for backward compatibility). Paths resolve via
+    ``_resolve_path_smart``, which prefers workspace-relative and
+    falls back to repo-relative when the path's first segment is a
+    top-level repo dir not present in the workspace.
+
+    Raises ``PathValidationError`` if the resolved path escapes the
+    allowed root.
+    """
+    security_root = (allowed_root or workspace_root).resolve()
+    resolved = _resolve_path_smart(requested, workspace_root, security_root)
+
+    if not str(resolved).startswith(str(security_root)):
         raise PathValidationError(
             f"Path '{requested}' resolves to '{resolved}' which is outside "
-            f"workspace root '{workspace_root}'"
+            f"allowed root '{security_root}'"
         )
 
     return resolved
@@ -172,8 +233,18 @@ class LocalToolProvider(ToolProvider):
         github_owner: str | None = None,
         github_repo: str | None = None,
         blocked_patterns: list[str] | None = None,
+        allowed_root: str | Path | None = None,
     ):
         self.workspace_root = Path(workspace_root).resolve()
+        # Broader security boundary that also permits sibling directories
+        # within the same git repo (e.g., dashboard/ when workspace is
+        # dev-suite/). Defaults to the enclosing git repo root if found,
+        # else falls back to workspace_root.
+        self.allowed_root = (
+            Path(allowed_root).resolve()
+            if allowed_root is not None
+            else _find_repo_root(self.workspace_root)
+        )
         self._blocked_patterns = (
             blocked_patterns if blocked_patterns is not None
             else DEFAULT_BLOCKED_PATTERNS
@@ -408,9 +479,9 @@ class LocalToolProvider(ToolProvider):
             )
 
     async def _filesystem_read(self, path: str) -> str:
-        """Read a file within the workspace."""
+        """Read a file within the allowed root."""
         self._check_blocked(path)
-        validated = _validate_path(path, self.workspace_root)
+        validated = _validate_path(path, self.workspace_root, self.allowed_root)
 
         if not validated.is_file():
             raise FileNotFoundError(f"File not found: {path}")
@@ -418,9 +489,9 @@ class LocalToolProvider(ToolProvider):
         return validated.read_text(encoding="utf-8")
 
     async def _filesystem_write(self, path: str, content: str) -> str:
-        """Write content to a file within the workspace."""
+        """Write content to a file within the allowed root."""
         self._check_blocked(path)
-        validated = _validate_path(path, self.workspace_root)
+        validated = _validate_path(path, self.workspace_root, self.allowed_root)
 
         validated.parent.mkdir(parents=True, exist_ok=True)
         validated.write_text(content, encoding="utf-8")
@@ -437,7 +508,7 @@ class LocalToolProvider(ToolProvider):
         preserves all surrounding code.
         """
         self._check_blocked(path)
-        validated = _validate_path(path, self.workspace_root)
+        validated = _validate_path(path, self.workspace_root, self.allowed_root)
 
         if not validated.is_file():
             raise FileNotFoundError(f"File not found: {path}")
@@ -474,8 +545,8 @@ class LocalToolProvider(ToolProvider):
         )
 
     async def _filesystem_list(self, path: str) -> str:
-        """List contents of a directory within the workspace."""
-        validated = _validate_path(path, self.workspace_root)
+        """List contents of a directory within the allowed root."""
+        validated = _validate_path(path, self.workspace_root, self.allowed_root)
 
         if not validated.is_dir():
             raise NotADirectoryError(f"Not a directory: {path}")
@@ -484,7 +555,12 @@ class LocalToolProvider(ToolProvider):
         lines = []
         for entry in entries:
             prefix = "[DIR] " if entry.is_dir() else "[FILE]"
-            rel = entry.relative_to(self.workspace_root)
+            # Report relative to allowed_root (usually the repo) so entries
+            # in sibling directories still have meaningful paths.
+            try:
+                rel = entry.relative_to(self.allowed_root)
+            except ValueError:
+                rel = entry.relative_to(self.workspace_root)
             # Normalize to forward slashes for consistent cross-platform output
             rel_posix = PurePosixPath(rel)
             lines.append(f"{prefix} {rel_posix}")

--- a/dev-suite/tests/test_tool_provider_cross_dir.py
+++ b/dev-suite/tests/test_tool_provider_cross_dir.py
@@ -1,0 +1,251 @@
+"""Tests for LocalToolProvider cross-directory resolution.
+
+Layer B gate test on #113 proved that #180's Fix 1 was partial:
+gather_context got repo-root resolution for reads, but the
+LocalToolProvider was still scoped to workspace_root only. When the
+workspace is a monorepo subfolder (the real self-dev scenario),
+filesystem_patch/write/read on sibling-dir paths failed or created
+ghost files under the workspace subfolder.
+
+These tests pin the fixed behavior: tool handlers share the same
+repo-root walk used by gather_context, and paths that clearly
+reference a top-level repo directory resolve repo-relative.
+
+Self-contained: uses a minimal inline Svelte-like fixture so the
+tests don't depend on any checked-in file. Standalone from the
+broader test_surgical_edits.py suite.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from src.tools.provider import (
+    LocalToolProvider,
+    PathValidationError,
+    _find_repo_root,
+    _resolve_path_smart,
+)
+
+# Minimal Svelte-like fixture: just enough structure to exercise the
+# surgical-edit scenario (Math.min clamp change), without pulling in
+# the full 209-line BottomPanel fixture from the other test file.
+FIXTURE_CONTENT = """<script lang=\"ts\">
+	import { onMount } from 'svelte';
+
+	let height = 0;
+
+	function handleMouseMove(e: MouseEvent) {
+		const newHeight = Math.max(60, Math.min(400, height + e.movementY));
+		height = newHeight;
+	}
+
+	onMount(() => {
+		console.log('mounted');
+	});
+</script>
+"""
+
+
+def _make_repo(tmp_path: Path) -> tuple[Path, Path]:
+    """Create a monorepo layout with .git/, dev-suite/, and a
+    dashboard/ sibling dir containing a Svelte file.
+
+    Returns (repo_root, workspace_root) where workspace_root is
+    dev-suite/ -- exactly the #113 Layer B scenario.
+    """
+    (tmp_path / ".git").mkdir()
+    workspace_root = tmp_path / "dev-suite"
+    workspace_root.mkdir()
+    target_dir = tmp_path / "dashboard" / "src" / "lib" / "components"
+    target_dir.mkdir(parents=True)
+    target_file = target_dir / "BottomPanel.svelte"
+    target_file.write_text(FIXTURE_CONTENT, encoding="utf-8")
+    return tmp_path, workspace_root
+
+
+# -- Unit tests for the helper functions --
+
+
+class TestFindRepoRoot:
+    def test_finds_git_parent(self, tmp_path):
+        (tmp_path / ".git").mkdir()
+        nested = tmp_path / "a" / "b" / "c"
+        nested.mkdir(parents=True)
+        assert _find_repo_root(nested) == tmp_path
+
+    def test_returns_start_when_no_git(self, tmp_path):
+        start = tmp_path / "orphan"
+        start.mkdir()
+        assert _find_repo_root(start) == start
+
+
+class TestResolvePathSmart:
+    def test_same_root_uses_workspace(self, tmp_path):
+        (tmp_path / "foo.txt").write_text("x")
+        resolved = _resolve_path_smart("foo.txt", tmp_path, tmp_path)
+        assert resolved == (tmp_path / "foo.txt").resolve()
+
+    def test_first_segment_only_in_repo_picks_repo(self, tmp_path):
+        ws = tmp_path / "dev-suite"
+        ws.mkdir()
+        (tmp_path / "dashboard").mkdir()
+        resolved = _resolve_path_smart("dashboard/x.ts", ws, tmp_path)
+        assert resolved == (tmp_path / "dashboard" / "x.ts").resolve()
+
+    def test_first_segment_in_workspace_picks_workspace(self, tmp_path):
+        ws = tmp_path / "dev-suite"
+        ws.mkdir()
+        (ws / "src").mkdir()
+        (tmp_path / "src").mkdir()
+        resolved = _resolve_path_smart("src/main.py", ws, tmp_path)
+        assert resolved == (ws / "src" / "main.py").resolve()
+
+    def test_unknown_first_segment_defaults_to_workspace(self, tmp_path):
+        ws = tmp_path / "dev-suite"
+        ws.mkdir()
+        resolved = _resolve_path_smart("new_folder/foo.py", ws, tmp_path)
+        assert resolved == (ws / "new_folder" / "foo.py").resolve()
+
+
+# -- Integration tests against LocalToolProvider --
+
+
+class TestLocalToolProviderAllowedRoot:
+    def test_auto_detects_repo_root_via_git_walk(self, tmp_path):
+        _, workspace_root = _make_repo(tmp_path)
+        provider = LocalToolProvider(workspace_root=workspace_root)
+        assert provider.allowed_root == tmp_path.resolve()
+        assert provider.workspace_root == workspace_root.resolve()
+
+    def test_falls_back_to_workspace_without_git(self, tmp_path):
+        ws = tmp_path / "no_git_here"
+        ws.mkdir()
+        provider = LocalToolProvider(workspace_root=ws)
+        assert provider.allowed_root == ws.resolve()
+
+    def test_explicit_override(self, tmp_path):
+        _, workspace_root = _make_repo(tmp_path)
+        explicit = tmp_path / "dashboard"
+        provider = LocalToolProvider(
+            workspace_root=workspace_root, allowed_root=explicit
+        )
+        assert provider.allowed_root == explicit.resolve()
+
+
+class TestToolHandlersCrossDirectory:
+    """Tool handlers must hit real sibling-dir files instead of
+    creating ghosts under workspace_root. Reproduces the #113 Layer B
+    failure mode."""
+
+    async def test_patch_hits_real_sibling_file_not_ghost(self, tmp_path):
+        _, workspace_root = _make_repo(tmp_path)
+        real_file = (
+            tmp_path / "dashboard" / "src" / "lib" / "components" / "BottomPanel.svelte"
+        )
+        ghost = (
+            workspace_root / "dashboard" / "src" / "lib" / "components" / "BottomPanel.svelte"
+        )
+        assert real_file.exists() and not ghost.exists()
+
+        provider = LocalToolProvider(workspace_root=workspace_root)
+        result = await provider.call_tool(
+            "filesystem_patch",
+            {
+                "path": "dashboard/src/lib/components/BottomPanel.svelte",
+                "search": "Math.min(400, height + e.movementY)",
+                "replace": "Math.min(window.innerHeight * 0.8, height + e.movementY)",
+            },
+        )
+        assert "Successfully patched" in result
+        assert "window.innerHeight * 0.8" in real_file.read_text(encoding="utf-8")
+        assert not ghost.exists(), (
+            "filesystem_patch must edit the real sibling-dir file, "
+            "not create a ghost copy under the workspace subfolder"
+        )
+
+    async def test_write_creates_at_repo_location_not_workspace(self, tmp_path):
+        _, workspace_root = _make_repo(tmp_path)
+        provider = LocalToolProvider(workspace_root=workspace_root)
+
+        result = await provider.call_tool(
+            "filesystem_write",
+            {
+                "path": "dashboard/src/lib/new_helper.ts",
+                "content": "export const hello = 'world';\n",
+            },
+        )
+        assert "Successfully wrote" in result
+
+        real_new = tmp_path / "dashboard" / "src" / "lib" / "new_helper.ts"
+        ghost_new = workspace_root / "dashboard" / "src" / "lib" / "new_helper.ts"
+        assert real_new.is_file()
+        assert not ghost_new.exists()
+        assert real_new.read_text(encoding="utf-8") == "export const hello = 'world';\n"
+
+    async def test_read_returns_real_sibling_content(self, tmp_path):
+        _, workspace_root = _make_repo(tmp_path)
+        provider = LocalToolProvider(workspace_root=workspace_root)
+
+        content = await provider.call_tool(
+            "filesystem_read",
+            {"path": "dashboard/src/lib/components/BottomPanel.svelte"},
+        )
+        assert "onMount" in content
+        assert "Math.min(400" in content
+
+    async def test_list_sibling_directory(self, tmp_path):
+        _, workspace_root = _make_repo(tmp_path)
+        provider = LocalToolProvider(workspace_root=workspace_root)
+
+        listing = await provider.call_tool(
+            "filesystem_list", {"path": "dashboard/src/lib/components"}
+        )
+        assert "BottomPanel.svelte" in listing
+        # Entry path is reported relative to repo root so subsequent
+        # filesystem_read calls resolve correctly.
+        assert "dashboard/src/lib/components/BottomPanel.svelte" in listing
+
+    async def test_workspace_relative_paths_still_work(self, tmp_path):
+        """Regression guard: paths whose first segment is a workspace
+        subdir still resolve workspace-relative."""
+        _, workspace_root = _make_repo(tmp_path)
+        (workspace_root / "src").mkdir()
+        (workspace_root / "src" / "main.py").write_text("workspace version", encoding="utf-8")
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "main.py").write_text("repo version", encoding="utf-8")
+
+        provider = LocalToolProvider(workspace_root=workspace_root)
+        content = await provider.call_tool(
+            "filesystem_read", {"path": "src/main.py"}
+        )
+        assert content == "workspace version"
+
+
+class TestCrossDirectorySecurityBoundary:
+    async def test_path_outside_repo_root_rejected(self, tmp_path):
+        _, workspace_root = _make_repo(tmp_path)
+        outside = tmp_path.parent / f"outside-{tmp_path.name}.secret"
+        outside.write_text("leaked", encoding="utf-8")
+        try:
+            provider = LocalToolProvider(workspace_root=workspace_root)
+            with pytest.raises(PathValidationError):
+                await provider.call_tool(
+                    "filesystem_read",
+                    {"path": f"../../{outside.name}"},
+                )
+        finally:
+            if outside.exists():
+                outside.unlink()
+
+    async def test_blocked_patterns_still_enforced_across_repo(self, tmp_path):
+        """.env at the repo root must still be rejected, even though
+        the boundary widened from workspace to repo."""
+        _, workspace_root = _make_repo(tmp_path)
+        (tmp_path / ".env").write_text("SECRET=x", encoding="utf-8")
+
+        provider = LocalToolProvider(workspace_root=workspace_root)
+        from src.tools.provider import BlockedPathError
+
+        with pytest.raises(BlockedPathError):
+            await provider.call_tool("filesystem_read", {"path": ".env"})


### PR DESCRIPTION
## Summary

Closes #180's Fix 1 gap. \`gather_context_node\` got repo-root walking in #180 so reads could reach sibling directories (e.g., \`dashboard/\` when the workspace is \`dev-suite/\`), but \`LocalToolProvider\` -- the backend for \`filesystem_read/write/patch/list\` -- was still scoped to \`workspace_root\` only. Agents could *see* sibling-dir files in Architect context but couldn't *edit* them.

### Changes

- Add \`_find_repo_root\` helper (mirrors the one in \`orchestrator.py\`)
- Add \`_resolve_path_smart\` — workspace-relative by default, repo-relative fallback when the first path segment names a top-level repo dir not present in the workspace
- Extend \`_validate_path\` with an optional \`allowed_root\` security boundary (default = \`workspace_root\`)
- \`LocalToolProvider\` auto-computes \`self.allowed_root = _find_repo_root(workspace_root)\` with an optional explicit override
- All four filesystem handlers (read/write/patch/list) now use the widened boundary
- \`filesystem_list\` reports entries relative to \`allowed_root\` so the Developer can feed them back into subsequent tool calls

### Why

Surfaced by the #179 Layer B gate-test rerun on issue #113. The agent's edit was **near-perfect** (+2/-1 diff, all preservation markers intact) -- it just landed at the wrong filesystem location because the tool provider couldn't reach the real file. Budget blew at 201% after retry; task failed.

With this PR: agents can actually write to sibling directories in monorepo workspaces, which is the prerequisite for self-dev on a repo like \`agent-dev\` that has \`dev-suite/\` + \`dashboard/\` siblings.

### Security

- \`allowed_root\` is the enclosing git repo (via \`.git\` walk), not an unbounded filesystem
- Paths escaping the repo root still raise \`PathValidationError\`
- \`is_blocked_path\` (secrets blocklist — .env, *.pem, *.key) is unchanged

### Test plan

New \`tests/test_tool_provider_cross_dir.py\` — 16 self-contained tests:

- Helpers (\`_find_repo_root\`, \`_resolve_path_smart\`): 6 cases
- \`LocalToolProvider.allowed_root\` init: 3 cases (auto, fallback, explicit override)
- Tool handlers crossing directories: 5 cases including the exact #113 patch scenario (ghost-file regression)
- Security: 2 cases (path outside repo rejected, secrets blocklist still enforced)

Results:
- [x] \`cd dev-suite && uv run --group api pytest tests/test_tool_provider_cross_dir.py -v\` — 16/16 pass
- [x] Full suite regression: 1020 passing, 2 skipped, 1 pre-existing Windows failure unrelated

### Related

- Discovered during #179 Layer B verification
- Independent of \`fix/failure-report-none-tolerance\` (other Layer B finding, separate PR)
- After this and the FailureReport PR land, I'll rerun Layer B — expect the #113 task to actually produce a clean surgical PR this time

🤖 Generated with [Claude Code](https://claude.com/claude-code)