### PR TITLE
fix(orchestrator): cross-directory resolution for apply_code and publish_code (completes #180's Fix 1)

### DIFF
--- a/dev-suite/src/orchestrator.py
+++ b/dev-suite/src/orchestrator.py
@@ -511,6 +511,38 @@ def _find_repo_root(start: Path) -> Path:
     return start
 
 
+def _resolve_target_path(
+    target_path: str, workspace_root: Path, repo_root: Path
+) -> Path:
+    """Resolve a Blueprint target_path against the correct root.
+
+    Mirrors LocalToolProvider's _resolve_path_smart so the orchestrator's
+    read-back of tool-written files finds the same file the agent wrote
+    via filesystem_patch/filesystem_write. Required when workspace_root
+    is a monorepo subfolder (e.g., dev-suite/) and target_path points
+    to a sibling dir (e.g., dashboard/foo.svelte) -- the tool wrote it
+    at repo_root/dashboard/foo.svelte, and we need to read from the
+    same place instead of a ghost under workspace_root/dashboard/.
+
+    Prefers workspace-relative (preserves existing semantics for paths
+    that are genuinely under the workspace). Falls back to repo-relative
+    when the first segment is a top-level repo dir not present in the
+    workspace.
+    """
+    workspace_root = workspace_root.resolve()
+    repo_root = repo_root.resolve()
+    if workspace_root == repo_root:
+        return (workspace_root / target_path).resolve()
+    parts = Path(target_path).parts
+    if parts:
+        first = parts[0]
+        in_workspace = (workspace_root / first).exists()
+        in_repo = (repo_root / first).exists()
+        if not in_workspace and in_repo:
+            return (repo_root / target_path).resolve()
+    return (workspace_root / target_path).resolve()
+
+
 def _extract_file_paths_from_text(text: str) -> list[str]:
     """Extract file-path-looking tokens from free-form task text.
 
@@ -1099,9 +1131,10 @@ Write clean, well-documented code."""
         if wrote_files and blueprint.target_files:
             ws_from_state = state.get("workspace_root", "")
             ws_root = (Path(ws_from_state).resolve() if ws_from_state else _get_workspace_root())
+            repo_root = _find_repo_root(ws_root)
             recovered_parts = []
             for target_path in blueprint.target_files:
-                full_path = ws_root / target_path
+                full_path = _resolve_target_path(target_path, ws_root, repo_root)
                 if full_path.is_file():
                     try:
                         file_content = full_path.read_text(encoding="utf-8")
@@ -1137,6 +1170,7 @@ async def apply_code_node(state: GraphState) -> dict:
         return {"parsed_files": [], "trace": trace}
     ws_from_state = state.get("workspace_root", "")
     workspace_root = Path(ws_from_state).resolve() if ws_from_state else _get_workspace_root()
+    repo_root = _find_repo_root(workspace_root)
     tool_calls_log = state.get("tool_calls_log", [])
     wrote_via_tools = any(
         tc.get("tool") in ("filesystem_write", "filesystem_patch")
@@ -1146,7 +1180,7 @@ async def apply_code_node(state: GraphState) -> dict:
     if wrote_via_tools and blueprint.target_files:
         disk_files = []
         for target_path in blueprint.target_files:
-            full_path = workspace_root / target_path
+            full_path = _resolve_target_path(target_path, workspace_root, repo_root)
             if full_path.is_file():
                 try:
                     content = full_path.read_text(encoding="utf-8")
@@ -1157,7 +1191,7 @@ async def apply_code_node(state: GraphState) -> dict:
         if disk_files:
             total_chars = sum(len(f["content"]) for f in disk_files)
             trace.append(f"apply_code: read {len(disk_files)} file(s) from disk (tool-written, {total_chars:,} chars total)")
-            logger.info("[APPLY_CODE] Read %d tool-written files (%d chars) from %s", len(disk_files), total_chars, workspace_root)
+            logger.info("[APPLY_CODE] Read %d tool-written files (%d chars) from %s", len(disk_files), total_chars, repo_root)
             return {"parsed_files": disk_files, "trace": trace}
         trace.append("apply_code: tool-written files not found on disk, falling back to parser")
     if not generated_code:
@@ -1180,7 +1214,7 @@ async def apply_code_node(state: GraphState) -> dict:
     written_count = 0
     for pf in safe_files:
         try:
-            target = workspace_root / pf.path
+            target = _resolve_target_path(pf.path, workspace_root, repo_root)
             target.parent.mkdir(parents=True, exist_ok=True)
             target.write_text(pf.content, encoding="utf-8")
             written_count += 1
@@ -1188,8 +1222,8 @@ async def apply_code_node(state: GraphState) -> dict:
         except Exception as e:
             logger.warning("[APPLY_CODE] Failed to write %s: %s", pf.path, e)
             trace.append(f"apply_code: failed to write {pf.path} -- {e}")
-    trace.append(f"apply_code: wrote {written_count} files ({total_chars:,} chars total) to {workspace_root}")
-    logger.info("[APPLY_CODE] Wrote %d files (%d chars) to %s", written_count, total_chars, workspace_root)
+    trace.append(f"apply_code: wrote {written_count} files ({total_chars:,} chars total) under {repo_root}")
+    logger.info("[APPLY_CODE] Wrote %d files (%d chars) under %s", written_count, total_chars, repo_root)
     parsed_files_data = [{"path": pf.path, "content": pf.content} for pf in safe_files]
     return {"parsed_files": parsed_files_data, "trace": trace}
 
@@ -1217,9 +1251,10 @@ async def qa_node(state: GraphState, config: RunnableConfig | None = None) -> di
         if wrote_via_tools and blueprint.target_files:
             ws_from_state = state.get("workspace_root", "")
             ws_root = (Path(ws_from_state).resolve() if ws_from_state else _get_workspace_root())
+            repo_root = _find_repo_root(ws_root)
             recovered_parts = []
             for target_path in blueprint.target_files:
-                full_path = ws_root / target_path
+                full_path = _resolve_target_path(target_path, ws_root, repo_root)
                 if full_path.is_file():
                     try:
                         file_content = full_path.read_text(encoding="utf-8")
@@ -1533,13 +1568,18 @@ async def _publish_code_async(state: dict) -> dict:
             return {"trace": trace}
         trace.append(f"publish_code: pushing {len(parsed_files)} file(s)")
         workspace_root = state.get("workspace_root", "")
-        # Issue #153: skip repo_subdir detection for remote workspaces —
+        # Issue #153: skip repo_subdir detection for remote workspaces --
         # files in a remote clone are already relative to repo root.
+        # Layer B finding: when a target_path is already repo-relative
+        # (e.g. "dashboard/...") we must NOT prepend repo_subdir, or the
+        # PR will push "dev-suite/dashboard/..." which doesn't exist.
         repo_subdir = ""
+        repo_root: Path | None = None
         if workspace_type != "github" and workspace_root:
             ws = Path(workspace_root).resolve()
             for parent in [ws, *ws.parents]:
                 if (parent / ".git").exists():
+                    repo_root = parent
                     try:
                         repo_subdir = str(ws.relative_to(parent))
                     except ValueError:
@@ -1548,8 +1588,24 @@ async def _publish_code_async(state: dict) -> dict:
         files_payload = []
         for pf in parsed_files:
             repo_path = pf["path"]
-            if repo_subdir and repo_subdir != ".":
-                repo_path = f"{repo_subdir}/{pf['path']}"
+            if (
+                repo_subdir
+                and repo_subdir != "."
+                and repo_root is not None
+            ):
+                first_segment = Path(pf["path"]).parts[0] if Path(pf["path"]).parts else ""
+                # Only prepend repo_subdir when the path is workspace-relative.
+                # If the first segment is a top-level repo dir OTHER than
+                # the workspace subdir itself, the path is already
+                # repo-relative (e.g., "dashboard/..." from a dev-suite
+                # workspace).
+                is_repo_sibling = (
+                    first_segment
+                    and first_segment != repo_subdir.split("/")[0]
+                    and (repo_root / first_segment).is_dir()
+                )
+                if not is_repo_sibling:
+                    repo_path = f"{repo_subdir}/{pf['path']}"
             files_payload.append({"path": repo_path, "content": pf["content"]})
         push_ok = await provider.push_files_batch(files=files_payload, branch=branch_name, message=f"feat({task_id}): implement {blueprint.instructions[:60]}")
         if not push_ok:

--- a/dev-suite/tests/test_orchestrator_cross_dir.py
+++ b/dev-suite/tests/test_orchestrator_cross_dir.py
@@ -1,0 +1,302 @@
+"""Tests for cross-directory resolution in orchestrator nodes.
+
+Layer B gate-test on #113 revealed that #187's tool-provider fix was
+not enough on its own: the Developer correctly used filesystem_patch
+to produce a +1/-1 surgical edit on the real sibling-dir file, but
+apply_code_node / publish_code_node still resolved target_path
+against workspace_root, so they missed the edit and published a
+bogus PR containing the Developer's text summary as `output.py`.
+
+These tests pin the fix for that gap:
+
+- `_resolve_target_path` helper mirrors provider's smart resolution
+- `apply_code_node` reads tool-written files from the real repo path
+- `publish_code_node`'s `files_payload` builds correct repo-relative
+  paths for cross-dir targets (no `dev-suite/dashboard/...` bogus)
+"""
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.agents.architect import Blueprint
+from src.orchestrator import (
+    GraphState,
+    WorkflowStatus,
+    _find_repo_root,
+    _resolve_target_path,
+    apply_code_node,
+    publish_code_node,
+)
+
+
+def _make_monorepo(tmp_path: Path) -> tuple[Path, Path, Path]:
+    """Create .git/, dev-suite/, dashboard/ layout.
+
+    Returns (repo_root, workspace_root=dev-suite, dashboard_root).
+    """
+    (tmp_path / ".git").mkdir()
+    workspace = tmp_path / "dev-suite"
+    workspace.mkdir()
+    dashboard = tmp_path / "dashboard" / "src" / "lib" / "components"
+    dashboard.mkdir(parents=True)
+    return tmp_path, workspace, dashboard
+
+
+# -- Helper tests --
+
+
+class TestResolveTargetPath:
+    def test_same_root_no_walk_needed(self, tmp_path):
+        (tmp_path / "foo.py").write_text("x", encoding="utf-8")
+        assert _resolve_target_path("foo.py", tmp_path, tmp_path) == (tmp_path / "foo.py").resolve()
+
+    def test_sibling_dir_resolves_to_repo(self, tmp_path):
+        repo, ws, _ = _make_monorepo(tmp_path)
+        # target lives at <repo>/dashboard/foo.svelte -- a sibling of workspace
+        assert _resolve_target_path(
+            "dashboard/src/lib/components/Foo.svelte", ws, repo
+        ) == (repo / "dashboard" / "src" / "lib" / "components" / "Foo.svelte").resolve()
+
+    def test_workspace_subdir_wins_when_ambiguous(self, tmp_path):
+        repo, ws, _ = _make_monorepo(tmp_path)
+        (ws / "src").mkdir()
+        (repo / "src").mkdir()
+        # "src/main.py" -- both workspace and repo have src/, prefer workspace
+        assert _resolve_target_path("src/main.py", ws, repo) == (ws / "src" / "main.py").resolve()
+
+    def test_unknown_first_segment_defaults_workspace(self, tmp_path):
+        _, ws, _ = _make_monorepo(tmp_path)
+        # "new_folder/foo.py" doesn't exist anywhere yet -- creating new
+        # under workspace is the safe default for the parser path.
+        assert _resolve_target_path("new_folder/foo.py", ws, tmp_path) == (ws / "new_folder" / "foo.py").resolve()
+
+
+class TestFindRepoRoot:
+    def test_walks_to_git_marker(self, tmp_path):
+        repo, ws, _ = _make_monorepo(tmp_path)
+        assert _find_repo_root(ws) == repo
+
+    def test_falls_back_to_start(self, tmp_path):
+        lonely = tmp_path / "no_git"
+        lonely.mkdir()
+        assert _find_repo_root(lonely) == lonely
+
+
+# -- apply_code_node cross-dir behavior --
+
+
+class TestApplyCodeNodeCrossDirectory:
+    """Layer B reproduction: filesystem_patch writes the real sibling
+    file; apply_code_node must read from the same location."""
+
+    async def test_reads_tool_written_sibling_file(self, tmp_path):
+        repo, workspace, dashboard = _make_monorepo(tmp_path)
+        target_rel = "dashboard/src/lib/components/Panel.svelte"
+        real_file = repo / target_rel
+        real_file.write_text("const x = 42;\n", encoding="utf-8")
+
+        state: GraphState = {
+            "task_description": "",
+            "generated_code": "",
+            "blueprint": Blueprint(
+                task_id="t1",
+                target_files=[target_rel],
+                instructions="patch it",
+                constraints=[],
+                acceptance_criteria=["ok"],
+                summary="patch the panel",
+            ),
+            "failure_report": None,
+            "status": WorkflowStatus.REVIEWING,
+            "retry_count": 0,
+            "tokens_used": 0,
+            "error_message": "",
+            "memory_context": [],
+            "memory_writes": [],
+            "trace": [],
+            "sandbox_result": None,
+            "parsed_files": [],
+            "tool_calls_log": [
+                {"tool": "filesystem_patch", "success": True, "agent": "developer"}
+            ],
+            "workspace_root": str(workspace),
+        }
+
+        result = await apply_code_node(state)
+        files = result["parsed_files"]
+        assert len(files) == 1
+        assert files[0]["path"] == target_rel
+        assert files[0]["content"] == "const x = 42;\n"
+        # Regression guard: must NOT fall back to parser (which would
+        # produce empty parsed_files since there's no generated_code).
+        assert not any("falling back to parser" in t for t in result["trace"])
+
+    async def test_workspace_relative_target_still_works(self, tmp_path):
+        """Paths that are legitimately workspace-relative still resolve
+        against workspace_root (regression guard)."""
+        repo, workspace, _ = _make_monorepo(tmp_path)
+        (workspace / "src").mkdir()
+        (workspace / "src" / "main.py").write_text("def hello(): pass", encoding="utf-8")
+
+        state: GraphState = {
+            "task_description": "",
+            "generated_code": "",
+            "blueprint": Blueprint(
+                task_id="t2",
+                target_files=["src/main.py"],
+                instructions="patch it",
+                constraints=[],
+                acceptance_criteria=["ok"],
+                summary="patch main",
+            ),
+            "failure_report": None,
+            "status": WorkflowStatus.REVIEWING,
+            "retry_count": 0,
+            "tokens_used": 0,
+            "error_message": "",
+            "memory_context": [],
+            "memory_writes": [],
+            "trace": [],
+            "sandbox_result": None,
+            "parsed_files": [],
+            "tool_calls_log": [
+                {"tool": "filesystem_write", "success": True, "agent": "developer"}
+            ],
+            "workspace_root": str(workspace),
+        }
+        result = await apply_code_node(state)
+        files = result["parsed_files"]
+        assert len(files) == 1
+        assert files[0]["content"] == "def hello(): pass"
+
+
+# -- publish_code_node files_payload --
+
+
+def _make_pr_mock(pr_number: int = 999):
+    m = MagicMock()
+    m.number = pr_number
+    m.id = f"#{pr_number}"
+    return m
+
+
+def _make_publish_state(workspace: Path, parsed_files: list[dict]) -> GraphState:
+    return {
+        "task_description": "t",
+        "blueprint": Blueprint(
+            task_id="fix-113-resize-cap",
+            target_files=[pf["path"] for pf in parsed_files],
+            instructions="fix",
+            constraints=[],
+            acceptance_criteria=["ok"],
+            summary="fix the resize cap",
+        ),
+        "generated_code": "",
+        "failure_report": None,
+        "status": WorkflowStatus.PASSED,
+        "retry_count": 0,
+        "tokens_used": 1000,
+        "error_message": "",
+        "memory_context": [],
+        "memory_writes": [],
+        "trace": [],
+        "sandbox_result": None,
+        "parsed_files": parsed_files,
+        "tool_calls_log": [],
+        "workspace_root": str(workspace),
+        "create_pr": True,
+    }
+
+
+class TestPublishCodeFilesPayloadCrossDirectory:
+    """Layer B finding: `files_payload` construction was prepending
+    `dev-suite/` to every path, so cross-dir targets like
+    `dashboard/foo.svelte` became `dev-suite/dashboard/foo.svelte` --
+    a path that doesn't exist in the repo. PRs ended up either
+    404'ing on push or containing bogus new files."""
+
+    @patch("src.api.github_prs.github_pr_provider")
+    async def test_sibling_dir_path_pushed_as_repo_relative(
+        self, mock_provider, tmp_path
+    ):
+        _, workspace, _ = _make_monorepo(tmp_path)
+        mock_provider.configured = True
+        mock_provider.owner = "Abernaughty"
+        mock_provider.repo = "agent-dev"
+        mock_provider.create_branch = AsyncMock(return_value=True)
+        mock_provider.push_files_batch = AsyncMock(return_value=True)
+        mock_provider.create_pr = AsyncMock(return_value=_make_pr_mock(999))
+
+        state = _make_publish_state(
+            workspace,
+            [{
+                "path": "dashboard/src/lib/components/BottomPanel.svelte",
+                "content": "// patched\n",
+            }],
+        )
+        await publish_code_node(state)
+
+        push_args = mock_provider.push_files_batch.call_args.kwargs
+        files_payload = push_args["files"]
+        assert len(files_payload) == 1
+        # Critical: path was NOT prefixed with "dev-suite/"
+        assert files_payload[0]["path"] == "dashboard/src/lib/components/BottomPanel.svelte"
+        assert files_payload[0]["content"] == "// patched\n"
+
+    @patch("src.api.github_prs.github_pr_provider")
+    async def test_workspace_relative_path_still_gets_repo_subdir_prefix(
+        self, mock_provider, tmp_path
+    ):
+        """Regression guard: when the target is genuinely workspace-relative
+        (not a sibling dir), the existing repo_subdir prefix behavior is
+        preserved."""
+        _, workspace, _ = _make_monorepo(tmp_path)
+        (workspace / "src").mkdir()
+        mock_provider.configured = True
+        mock_provider.owner = "Abernaughty"
+        mock_provider.repo = "agent-dev"
+        mock_provider.create_branch = AsyncMock(return_value=True)
+        mock_provider.push_files_batch = AsyncMock(return_value=True)
+        mock_provider.create_pr = AsyncMock(return_value=_make_pr_mock(1000))
+
+        state = _make_publish_state(
+            workspace,
+            [{"path": "src/main.py", "content": "print('hi')\n"}],
+        )
+        await publish_code_node(state)
+
+        files_payload = mock_provider.push_files_batch.call_args.kwargs["files"]
+        assert len(files_payload) == 1
+        # workspace is dev-suite/, so workspace-relative "src/main.py" becomes
+        # "dev-suite/src/main.py" for the PR (existing behavior preserved).
+        assert files_payload[0]["path"] == "dev-suite/src/main.py"
+
+    @patch("src.api.github_prs.github_pr_provider")
+    async def test_mixed_payload_paths_routed_correctly(
+        self, mock_provider, tmp_path
+    ):
+        """Target_files can mix sibling-dir and workspace-relative paths;
+        each should route independently."""
+        _, workspace, _ = _make_monorepo(tmp_path)
+        (workspace / "src").mkdir()
+        mock_provider.configured = True
+        mock_provider.owner = "Abernaughty"
+        mock_provider.repo = "agent-dev"
+        mock_provider.create_branch = AsyncMock(return_value=True)
+        mock_provider.push_files_batch = AsyncMock(return_value=True)
+        mock_provider.create_pr = AsyncMock(return_value=_make_pr_mock(1001))
+
+        state = _make_publish_state(
+            workspace,
+            [
+                {"path": "dashboard/src/lib/x.svelte", "content": "<script>\n"},
+                {"path": "src/utils.py", "content": "# helper\n"},
+            ],
+        )
+        await publish_code_node(state)
+
+        paths = [pf["path"] for pf in mock_provider.push_files_batch.call_args.kwargs["files"]]
+        assert "dashboard/src/lib/x.svelte" in paths
+        assert "dev-suite/src/utils.py" in paths

--- a/dev-suite/tests/test_orchestrator_cross_dir.py
+++ b/dev-suite/tests/test_orchestrator_cross_dir.py
@@ -18,8 +18,6 @@ These tests pin the fix for that gap:
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
-
 from src.agents.architect import Blueprint
 from src.orchestrator import (
     GraphState,


### PR DESCRIPTION
## Summary

Closes the last gap in #180's Fix 1. After #187 gave \`LocalToolProvider\` repo-root resolution, the Developer could finally call \`filesystem_patch\` on a sibling-dir target and land a correct edit on the real file. But \`apply_code_node\` and \`_publish_code_async\` were still workspace-scoped, so:

1. \`apply_code_node\` looked for tool-written files at \`<workspace>/dashboard/...\`, didn't find them, logged \"tool-written files not found on disk, falling back to parser\", and parsed the Developer's 392-char text summary as an \`output.py\` ghost file.
2. \`_publish_code_async\` then pushed the ghost (\`output.py: +1 -0\`) to the PR and prefixed \`dev-suite/\` to every target_path, so even a corrected \`apply_code_node\` would've pushed \`dev-suite/dashboard/...\` which doesn't exist in the repo.

Layer B #113 rerun on 2026-04-16 demonstrated both: agent produced a perfect +1/-1 surgical edit on \`dashboard/src/lib/components/BottomPanel.svelte\` but [PR #189](https://github.com/Abernaughty/agent-dev/pull/189) landed with the ghost instead.

## Changes

- Add \`_resolve_target_path(target_path, workspace_root, repo_root)\` helper in \`orchestrator.py\` mirroring \`_resolve_path_smart\` in \`provider.py\`. Kept local (not an import) to keep orchestrator <-> tools layering clean.
- \`developer_node\` recovery path: uses the helper.
- \`apply_code_node\` read and parser-write paths: both use the helper.
- \`qa_node\` recovery path: uses the helper.
- \`_publish_code_async\`: \`files_payload\` construction only prepends \`repo_subdir\` when the target is workspace-internal. Cross-dir targets (\`dashboard/...\`) stay repo-relative; workspace-internal targets (\`src/main.py\` under \`dev-suite/\`) keep the \`dev-suite/\` prefix for backward compat.

## Test plan

New \`tests/test_orchestrator_cross_dir.py\` -- 11 tests:

| Class | What |
|---|---|
| \`TestResolveTargetPath\` | same-root; sibling-dir → repo; ambiguous → workspace wins; unknown → workspace default |
| \`TestFindRepoRoot\` | .git walk + fallback |
| \`TestApplyCodeNodeCrossDirectory\` | reads tool-written sibling file end-to-end; workspace-relative still works |
| \`TestPublishCodeFilesPayloadCrossDirectory\` | sibling path NOT prefixed with repo_subdir; workspace path still gets prefix; mixed payload routes each correctly |

Results:
- [x] \`cd dev-suite && uv run --group api pytest tests/test_orchestrator_cross_dir.py -v\` — 11/11 pass
- [x] Full suite: 1028 passing, 2 skipped, 3 failures (2 pre-existing \`test_api.py\` failures unrelated to this change — same failures occur on clean \`main\`; 1 pre-existing Windows backslash in \`test_gather_context.py\`)
- [ ] **Integration**: Layer B #113 rerun after merge — expect the opened PR to contain \`dashboard/src/lib/components/BottomPanel.svelte: +1 -1\`, no ghost files.

## Related

Final piece of the self-dev readiness stack:

1. #183 smoke-test.sh workspace field
2. #184 load_dotenv(override=True)
3. #185 Layer A integration tests for #179
4. #186 FailureReport None-tolerance
5. #187 LocalToolProvider cross-directory
6. **this** — orchestrator cross-directory

After this lands, the agent team can self-modify any file anywhere in the repo from any workspace subfolder and ship a clean PR. That completes the behavior goal behind #179.

🤖 Generated with [Claude Code](https://claude.com/claude-code)