### PR TITLE
fix(api/tests): unbreak test_api.py regression from PR #184

### DIFF
--- a/dev-suite/src/api/state.py
+++ b/dev-suite/src/api/state.py
@@ -34,8 +34,18 @@ from datetime import datetime, timezone
 # This was the root cause of the WORKSPACE_ROOT=dev-suite bug.
 from dotenv import load_dotenv
 
-# override=True so .env beats any stale value pre-set in the parent shell.
-load_dotenv(override=True)
+# override=False (default) so this module-level call can't clobber values
+# intentionally set by tests via conftest.py (the TEST_WORKSPACE_ROOT
+# override would otherwise be silently reset to .env's WORKSPACE_ROOT and
+# every test posting to /tasks with the temp workspace would 403).
+#
+# The stale-shell-env defensive override (PR #184) lives in main.py --
+# that fires when uvicorn actually starts, AFTER this singleton is built,
+# and clobbers any stale API keys before the orchestrator runs its first
+# LLM call. state.py only needs to populate WORKSPACE_ROOT and model-name
+# env vars for the state_manager singleton; those are not the variables
+# the stale-shell-env attack vector is about.
+load_dotenv()
 
 from ..workspace import WorkspaceManager
 from .events import EventType, SSEEvent, event_bus

--- a/dev-suite/tests/conftest.py
+++ b/dev-suite/tests/conftest.py
@@ -49,3 +49,23 @@ def pytest_collection_modifyitems(config, items):
         for item in items:
             if "live" in item.keywords:
                 item.add_marker(skip)
+
+
+@pytest.fixture(autouse=True)
+def _restore_test_workspace_root(monkeypatch):
+    """Re-assert the test WORKSPACE_ROOT override before every test.
+
+    The module-level ``os.environ["WORKSPACE_ROOT"] = _TEST_WORKSPACE``
+    above runs once at conftest import. But ``src.api.main``'s
+    ``load_dotenv(override=True)`` (PR #184, stale-shell-env defense)
+    clobbers the value back to ``.env``'s WORKSPACE_ROOT as soon as
+    ``from src.api.main import app`` is executed. Fixtures like
+    ``client()`` in test_api.py then build a fresh ``StateManager()``
+    whose ``WorkspaceManager`` reads the clobbered env and rejects
+    the temp workspace with 403.
+
+    Re-asserting with monkeypatch here means every test sees the temp
+    workspace regardless of module-import-time env manipulation, and
+    monkeypatch auto-restores the prior value after the test.
+    """
+    monkeypatch.setenv("WORKSPACE_ROOT", _TEST_WORKSPACE)


### PR DESCRIPTION
## Summary

Fixes the two test_api.py failures (\`test_create_task\`, \`test_cancel_task\`) that were mislabeled as "pre-existing" in the test plans for #187 and #190. Both were actually a regression from #184 (\`load_dotenv(override=True)\`).

## What broke

- \`conftest.py\` at import time: loads .env, then assigns \`os.environ["WORKSPACE_ROOT"] = _TEST_WORKSPACE\` (a tempdir).
- test_api.py imports \`from src.api.main import app\`. Module-load runs state.py's \`load_dotenv(override=True)\` first — **clobbers WORKSPACE_ROOT** with .env's real value. main.py's own \`override=True\` runs next — same clobber.
- The \`client\` fixture then constructs a fresh \`StateManager()\` whose \`WorkspaceManager\` reads the clobbered env, ends up with only the real workspace in allowed_dirs.
- Tests POST /tasks with \`workspace=TEST_WORKSPACE_ROOT\` → **403 Forbidden**.
- Cascading: \`test_cancel_task\` crashes with \`KeyError: 'data'\` because the 403 response body has no \`data\` key.

## Fix

1. **\`src/api/state.py\`**: revert to \`load_dotenv()\` (default, no override). The stale-shell-env defense still lives in \`main.py\`. state.py only populates WORKSPACE_ROOT and model-name env vars for the singleton build — those aren't the stale-shell-env attack vector (API keys are, and main.py still overrides for those).

2. **\`tests/conftest.py\`**: add an autouse fixture that re-asserts \`WORKSPACE_ROOT\` via \`monkeypatch\` before every test. main.py's module-level \`override=True\` runs once at import, AFTER conftest's initial env setup, so per-test re-assertion is the simplest way to make fresh \`StateManager\` fixtures honor the test override without reverting #184's defensive guard.

## Test plan

- [x] \`uv run --group api pytest tests/test_api.py -q\` — 39/39 pass (previously 37 passed, 2 failed)
- [x] \`uv run --group api pytest tests/ -q -m "not integration"\` — 1019 passed, 2 skipped, only 1 pre-existing Windows backslash failure in \`test_gather_context.py\` (unchanged; unrelated)

## Related

- Introduced by #184 (defensive \`load_dotenv\` override).
- Would also unblock clean CI on #190 (orchestrator cross-dir) — both of these make the test suite fully green again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)