### PR TITLE
fix(planner): reconcile system prompt with pre-fetched GitHub context

### DIFF
--- a/dev-suite/src/agents/planner.py
+++ b/dev-suite/src/agents/planner.py
@@ -41,7 +41,7 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
-from ..tools.github_fetch import fetch_refs_as_context_items
+from ..tools.github_fetch import extract_github_refs, fetch_refs_as_context_items
 
 logger = logging.getLogger(__name__)
 
@@ -501,8 +501,14 @@ You are a Task Planner for an AI agent team. Your job is to help the user \
 create a clear, complete task specification before it's sent to the Architect \
 agent for blueprint generation.
 
-You have ZERO tool access — no filesystem, no GitHub, no sandbox. You only \
-work with information the user provides and any auto-detected project context.
+You do not call tools directly. However, when the user references a GitHub \
+issue or PR (e.g. "fix #42", "review issue #113"), the orchestrator \
+deterministically pre-fetches the issue/PR body and injects it as a \
+message labelled "=== PRE-FETCHED GITHUB CONTEXT ===" below. Treat that \
+block as authoritative source material — never tell the user you cannot \
+access GitHub when that block is present; summarise its contents and move \
+the task forward. You also work with information the user provides and \
+any auto-detected project context.
 
 Your responsibilities:
 1. Understand the user's objective
@@ -575,10 +581,12 @@ def _format_github_context_block(github_context: list[dict]) -> str:
     if not github_context:
         return ""
     sections: list[str] = [
-        "Pre-fetched GitHub references (from the user's message; "
-        "use these to orient the task, do not ask the user to paste "
-        "them):",
+        "=== PRE-FETCHED GITHUB CONTEXT ===",
+        "The orchestrator already fetched the GitHub issue/PR the user "
+        "mentioned. Use these summaries to orient the task. Do not tell "
+        "the user you cannot access GitHub — the content is below.",
     ]
+    body_count = 0
     for item in github_context:
         if not isinstance(item, dict):
             continue
@@ -587,8 +595,10 @@ def _format_github_context_block(github_context: list[dict]) -> str:
         if not content:
             continue
         sections.append(f"--- {path} ---\n{content}")
-    if len(sections) == 1:
+        body_count += 1
+    if body_count == 0:
         return ""
+    sections.append("=== END PRE-FETCHED GITHUB CONTEXT ===")
     return "\n\n".join(sections)
 
 
@@ -631,12 +641,25 @@ async def _prefetch_github_refs_for_message(
     messages that mention the same issue don't re-fetch). Best-effort:
     missing GITHUB_TOKEN or network errors quietly return no new items.
     """
-    token = os.getenv("GITHUB_TOKEN", "")
-    if not token:
-        return []
-
     default_owner = os.getenv("GITHUB_OWNER", "")
     default_repo = os.getenv("GITHUB_REPO", "")
+
+    detected_refs = extract_github_refs(
+        user_message,
+        default_owner=default_owner,
+        default_repo=default_repo,
+        max_refs=PLANNER_MAX_GITHUB_REFS,
+    )
+
+    token = os.getenv("GITHUB_TOKEN", "")
+    if not token:
+        if detected_refs:
+            logger.warning(
+                "[PLANNER] Detected %d GitHub ref(s) in session %s but "
+                "GITHUB_TOKEN is not set — pre-fetch skipped",
+                len(detected_refs), session.session_id,
+            )
+        return []
 
     existing_paths = {
         item.get("path") for item in session.task_spec.github_context
@@ -651,6 +674,12 @@ async def _prefetch_github_refs_for_message(
         max_refs=PLANNER_MAX_GITHUB_REFS,
         max_chars=PLANNER_GITHUB_REF_MAX_CHARS,
     )
+    if detected_refs and not items:
+        logger.warning(
+            "[PLANNER] Detected %d GitHub ref(s) in session %s but "
+            "fetch returned 0 items (bad token, 404, or network error)",
+            len(detected_refs), session.session_id,
+        )
     new_items = [
         item for item in items
         if item.get("path") and item["path"] not in existing_paths

--- a/dev-suite/tests/test_planner.py
+++ b/dev-suite/tests/test_planner.py
@@ -741,3 +741,137 @@ class TestPlannerGitHubPrefetch:
 
         assert response.task_spec.objective == "Fix"
         assert session.task_spec.github_context == []
+
+
+# =========================================================================
+# System-prompt reconciliation with pre-fetched GitHub context (Issue #193)
+# =========================================================================
+
+
+class TestPlannerSystemPromptReconciliation:
+    """Regression tests for the bug where the Planner's system prompt
+    told the LLM it had "ZERO tool access" even when the orchestrator
+    had pre-fetched GitHub issue/PR bodies. See issue #193 AC #3.
+    """
+
+    @pytest.mark.asyncio
+    async def test_prompt_does_not_claim_zero_tool_access_when_context_present(
+        self, monkeypatch,
+    ):
+        """System messages sent to the LLM must not tell it it has ZERO
+        tool access once github_context is populated, and must include
+        the PRE-FETCHED GITHUB CONTEXT marker so the LLM knows to use
+        the injected data instead of apologizing about missing tools.
+        """
+        from src.agents.planner import create_planner_session, send_planner_message
+
+        monkeypatch.setenv("GITHUB_TOKEN", "fake-token")
+        monkeypatch.setenv("GITHUB_OWNER", "Abernaughty")
+        monkeypatch.setenv("GITHUB_REPO", "agent-dev")
+
+        session = create_planner_session(workspace="/proj", languages=["Python"])
+
+        fetched = {
+            "path": "github://Abernaughty/agent-dev/issues/113",
+            "content": (
+                "Issue #113: Fix the planner\n\nState: open\n\n"
+                "Body: the planner needs real GitHub context"
+            ),
+            "truncated": False,
+            "source": "github_issue",
+        }
+        captured: list[list[dict]] = []
+
+        async def fake_fetch(*args, **kwargs):
+            return [fetched]
+
+        async def fake_llm(model_name, messages):
+            captured.append(messages)
+            return '```json\n{"objective": "Fix the planner"}\n```'
+
+        with patch(
+            "src.agents.planner.fetch_refs_as_context_items",
+            side_effect=fake_fetch,
+        ), patch(
+            "src.agents.planner._call_planner_llm",
+            side_effect=fake_llm,
+        ):
+            await send_planner_message(
+                session,
+                "Review and implement the fix for GitHub Issue #113.",
+            )
+
+        assert captured, "LLM must have been called"
+        system_content = "\n".join(
+            m["content"] for m in captured[0] if m["role"] == "system"
+        )
+
+        # The self-denial phrasing is gone.
+        assert "ZERO tool access" not in system_content
+
+        # The LLM is explicitly told not to claim no GitHub access when
+        # context is present, and the pre-fetched block is clearly marked.
+        assert "PRE-FETCHED GITHUB CONTEXT" in system_content
+        assert "github://Abernaughty/agent-dev/issues/113" in system_content
+
+    def test_context_block_has_start_and_end_markers(self):
+        """The pre-fetched block uses explicit start/end markers that
+        match the phrasing the system prompt tells the LLM to look for.
+        """
+        from src.agents.planner import _format_github_context_block
+
+        block = _format_github_context_block([
+            {
+                "path": "github://acme/widgets/issues/42",
+                "content": "Body text",
+                "source": "github_issue",
+            }
+        ])
+
+        assert "=== PRE-FETCHED GITHUB CONTEXT ===" in block
+        assert "=== END PRE-FETCHED GITHUB CONTEXT ===" in block
+        assert "github://acme/widgets/issues/42" in block
+        assert "Body text" in block
+
+    def test_context_block_empty_when_no_items_have_content(self):
+        """Empty or malformed context items produce no block at all — we
+        don't want to emit markers with no body and confuse the LLM.
+        """
+        from src.agents.planner import _format_github_context_block
+
+        assert _format_github_context_block([]) == ""
+        assert _format_github_context_block([{"path": "x", "content": ""}]) == ""
+        assert _format_github_context_block(["not-a-dict"]) == ""  # type: ignore[list-item]
+
+    @pytest.mark.asyncio
+    async def test_warns_when_refs_detected_but_no_token(
+        self, monkeypatch, caplog,
+    ):
+        """Missing GITHUB_TOKEN should log a warning when the user's
+        message actually contained refs, so operators can diagnose why
+        pre-fetch silently returned nothing.
+        """
+        import logging as _logging
+
+        from src.agents.planner import create_planner_session, send_planner_message
+
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        monkeypatch.setenv("GITHUB_OWNER", "Abernaughty")
+        monkeypatch.setenv("GITHUB_REPO", "agent-dev")
+
+        session = create_planner_session(workspace="/proj", languages=["Python"])
+
+        async def fake_llm(model_name, messages):
+            return '```json\n{}\n```'
+
+        with caplog.at_level(_logging.WARNING, logger="src.agents.planner"):
+            with patch(
+                "src.agents.planner._call_planner_llm",
+                side_effect=fake_llm,
+            ):
+                await send_planner_message(session, "Fix issue #113")
+
+        assert any(
+            "GITHUB_TOKEN is not set" in record.message
+            for record in caplog.records
+        )


### PR DESCRIPTION
## Summary

- Planner's `_PLANNER_SYSTEM_PROMPT` no longer declares "ZERO tool access" — it now explains the deterministic pre-fetch flow from PR #195 and tells the LLM never to deny GitHub access when the pre-fetched block is present.
- `_format_github_context_block` wraps the payload in explicit `=== PRE-FETCHED GITHUB CONTEXT ===` / `=== END PRE-FETCHED GITHUB CONTEXT ===` markers that the system prompt references by name.
- `_prefetch_github_refs_for_message` now logs a `warning` (not a silent skip) when refs were detected but `GITHUB_TOKEN` is missing or the fetch returned zero items.

Closes the AC #3 gap in #193: "Planner fetches GitHub issues/PRs when referenced (no more 'what language is this?')". ACs #1, #2, #4–#9 were already satisfied by #194, #195, and #196.

### Root cause

With "Review and implement the fix for GitHub Issue #113", the regex correctly matched, `fetch_refs_as_context_items` populated `session.task_spec.github_context`, and `_format_github_context_block` injected the body as a secondary system message. But the **primary** system prompt was static and kept telling the LLM it had zero tool access — the LLM followed the canonical instruction and apologized to the user instead of reading the injected block. The existing integration test at `tests/test_architect_two_phase.py::TestFixIssue113Integration` mocked the Planner LLM response, so it never exercised this contradiction.

## Test plan

- [x] `uv run pytest tests/test_planner.py -v` — 61/61 pass (4 new in `TestPlannerSystemPromptReconciliation`)
- [x] `uv run pytest tests/test_github_fetch.py tests/test_mcp_tools.py tests/test_architect_two_phase.py` — 166/166 pass
- [x] Full suite `uv run pytest tests/ -m "not integration"` — only 2 pre-existing unrelated failures (`test_workspace.py::test_from_env_defaults`, `test_gather_context.py::test_keyword_matching`), confirmed on `main`
- [ ] Manual smoke after merge: start backend + dashboard, send `"Review and implement the fix for GitHub Issue #113."` in the Planner and confirm it references the issue body instead of apologizing.

Refs #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)