### PR TITLE
fix(tools): stop truncating GitHub issue bodies in pre-fetch

### DIFF
--- a/dev-suite/src/agents/planner.py
+++ b/dev-suite/src/agents/planner.py
@@ -56,11 +56,6 @@ SESSION_TTL_SECONDS = 30 * 60
 # the context injection bounded if the user pastes a long list of refs.
 PLANNER_MAX_GITHUB_REFS = 5
 
-# Issue #193: per-ref body char budget for the Planner's pre-fetch.
-# Tighter than the Architect's gather_context (2000) because the
-# Planner only needs a quick orientation, not full issue bodies.
-PLANNER_GITHUB_REF_MAX_CHARS = 1200
-
 # Issue #193: loose heuristic for "the user mentioned a `#N` ref but we
 # couldn't resolve it." Used only for warning diagnostics when the
 # precise `extract_github_refs` returns nothing because no default
@@ -774,7 +769,6 @@ async def _prefetch_github_refs_for_message(
         default_repo=default_repo,
         token=token,
         max_refs=PLANNER_MAX_GITHUB_REFS,
-        max_chars=PLANNER_GITHUB_REF_MAX_CHARS,
     )
     if detected_refs and not items:
         logger.warning(

--- a/dev-suite/src/orchestrator.py
+++ b/dev-suite/src/orchestrator.py
@@ -814,7 +814,7 @@ async def gather_context_node(state: GraphState) -> dict:
                 continue
             item = await fetch_issue_or_pr(
                 ref.owner, ref.repo, ref.number,
-                token=github_token, max_chars=2000,
+                token=github_token,
             )
             if item is not None:
                 new_github_items.append(item)

--- a/dev-suite/src/tools/github_fetch.py
+++ b/dev-suite/src/tools/github_fetch.py
@@ -170,8 +170,16 @@ def extract_github_refs(
     return refs
 
 
-def _summarize_issue_payload(data: dict, max_chars: int) -> tuple[str, bool]:
+def _summarize_issue_payload(
+    data: dict, max_chars: int | None,
+) -> tuple[str, bool]:
     """Build a compact text summary from the GitHub issue/PR JSON.
+
+    When ``max_chars`` is ``None``, the body is passed through intact —
+    arbitrary truncation risks cutting acceptance criteria or other
+    load-bearing context, so ``None`` is the default for the Planner and
+    orchestrator pre-fetch paths. Callers that need a hard cap (tests,
+    experimental budgets) can still pass an explicit int.
 
     Returns (summary_text, truncated_flag).
     """
@@ -197,12 +205,13 @@ def _summarize_issue_payload(data: dict, max_chars: int) -> tuple[str, bool]:
     if not body:
         return header, False
 
-    # Leave room for header + a blank line
-    body_budget = max(0, max_chars - len(header) - 2)
     truncated = False
-    if len(body) > body_budget:
-        body = body[:body_budget].rstrip() + "\n... [truncated]"
-        truncated = True
+    if max_chars is not None:
+        # Leave room for header + a blank line
+        body_budget = max(0, max_chars - len(header) - 2)
+        if len(body) > body_budget:
+            body = body[:body_budget].rstrip() + "\n... [truncated]"
+            truncated = True
 
     return f"{header}\n\n{body}", truncated
 
@@ -212,7 +221,7 @@ async def fetch_issue_or_pr(
     repo: str,
     number: int,
     token: str,
-    max_chars: int = 2000,
+    max_chars: int | None = None,
     timeout: float = 10.0,
 ) -> dict | None:
     """Fetch a single GitHub issue or PR as a gathered_context-shaped dict.
@@ -278,7 +287,7 @@ async def fetch_refs_as_context_items(
     default_repo: str,
     token: str,
     max_refs: int = 5,
-    max_chars: int = 2000,
+    max_chars: int | None = None,
 ) -> list[dict]:
     """Extract and fetch issue/PR refs from text as context entries.
 

--- a/dev-suite/tests/test_github_fetch.py
+++ b/dev-suite/tests/test_github_fetch.py
@@ -223,7 +223,8 @@ class TestFetchIssueOrPr:
         assert "PR #200" in result["content"]
 
     @pytest.mark.asyncio
-    async def test_body_truncated(self):
+    async def test_body_truncated_when_max_chars_set(self):
+        """Opt-in truncation still works for callers that pass a cap."""
         big_body = "X" * 5000
         payload = {"number": 1, "title": "t", "state": "open", "body": big_body}
         mock_client = AsyncMock()
@@ -239,6 +240,32 @@ class TestFetchIssueOrPr:
         assert "[truncated]" in result["content"]
         # Overall content respects budget (roughly)
         assert len(result["content"]) <= 600
+
+    @pytest.mark.asyncio
+    async def test_body_not_truncated_by_default(self):
+        """Default (max_chars=None) passes the full issue body through.
+
+        Regression for real Issue #113: a 1220-char body was silently
+        chopped mid-AC block ("Minimum h...") under the old 1200-char
+        default, dropping load-bearing context. Any arbitrary cap risks
+        the same problem, so the default is now "no truncation."
+        """
+        big_body = "Z" * 5000
+        payload = {"number": 113, "title": "t", "state": "open", "body": big_body}
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.__aexit__.return_value = None
+        mock_client.get.return_value = _make_response(200, payload)
+
+        with patch("src.tools.github_fetch.httpx.AsyncClient", return_value=mock_client):
+            result = await fetch_issue_or_pr("o", "r", 113, token="t")
+
+        assert result is not None
+        assert result["truncated"] is False
+        assert "[truncated]" not in result["content"]
+        # Full body survived — length strictly exceeds any previous cap.
+        assert len(result["content"]) >= 5000
+        assert result["content"].count("Z") == 5000
 
     @pytest.mark.asyncio
     async def test_non_200_returns_none(self):


### PR DESCRIPTION
## Summary

Manual smoke of real [Issue #113](https://github.com/Abernaughty/agent-dev/issues/113) in both LOCAL and REMOTE Planner modes revealed that the 1200-char Planner body cap (and the 2000-char `gather_context` cap) silently chopped the fetched issue **mid-Acceptance-Criteria block**. The Planner saw *"Minimum h..."* instead of the actual value (*"60px existing minimum is fine"*) and had to ask the user for it — an unnecessary round-trip that defeats the whole point of pre-fetching.

Any arbitrary cap risks the same problem on the next issue that's `N+1` chars long. The fix is to stop imposing one by default, not to pick a bigger magic number.

## Changes

- `_summarize_issue_payload(max_chars)` treats `None` as "no truncation"
- `fetch_issue_or_pr(max_chars=None)` is the new default
- `fetch_refs_as_context_items(max_chars=None)` is the new default
- Removed `PLANNER_GITHUB_REF_MAX_CHARS` constant and its call-site arg
- Removed `max_chars=2000` from `gather_context_node`
- Opt-in truncation still works — callers that genuinely need a cap (tests, experimental budgets) can still pass an explicit int

## Test plan

- [x] `uv run pytest tests/test_github_fetch.py tests/test_planner.py tests/test_gather_context.py tests/test_architect_two_phase.py tests/test_api.py` — 196/196 pass (1 pre-existing unrelated Windows path-separator failure confirmed on `main`)
- [x] Renamed `test_body_truncated` → `test_body_truncated_when_max_chars_set` (opt-in truncation still works)
- [x] New `test_body_not_truncated_by_default` — 5000-char body passes through intact, 5000 `Z`s survive the round-trip
- [x] Post-merge manual smoke: same Issue #113 scenario — Planner now sees the full AC block including *"Minimum height preserved (60px existing minimum is fine)"* without clarifying

Closes the AC #3f follow-up from #193.

Refs #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)