### PR TITLE
feat(planner): bind read-only filesystem tools to the Planner LLM

### DIFF
--- a/dev-suite/src/agents/planner.py
+++ b/dev-suite/src/agents/planner.py
@@ -1003,9 +1003,9 @@ def _get_planner_readonly_tools(workspace: str) -> list:
         # Imported here to avoid a top-level dependency cycle — the tools
         # module pulls in provider + bridge, which aren't needed when
         # Planner is used in isolation (tests, CLI smoke).
+        from ..orchestrator import _get_mcp_config_path
         from ..tools import create_provider, load_mcp_config
         from ..tools.mcp_bridge import READONLY_TOOLS, get_tools
-        from ..orchestrator import _get_mcp_config_path
     except Exception as exc:  # noqa: BLE001
         logger.debug("[PLANNER] Tool imports failed: %s", exc)
         return []

--- a/dev-suite/src/agents/planner.py
+++ b/dev-suite/src/agents/planner.py
@@ -56,6 +56,14 @@ SESSION_TTL_SECONDS = 30 * 60
 # the context injection bounded if the user pastes a long list of refs.
 PLANNER_MAX_GITHUB_REFS = 5
 
+# Planner read-only tool loop turn cap. Matches the Architect's Phase 2
+# budget — enough turns for a few ls/read calls to orient the spec,
+# bounded so a misbehaving LLM can't drain tokens chasing the codebase.
+try:
+    MAX_PLANNER_TOOL_TURNS = int(os.getenv("MAX_PLANNER_TOOL_TURNS", "4"))
+except ValueError:
+    MAX_PLANNER_TOOL_TURNS = 4
+
 # Issue #193: loose heuristic for "the user mentioned a `#N` ref but we
 # couldn't resolve it." Used only for warning diagnostics when the
 # precise `extract_github_refs` returns nothing because no default
@@ -563,13 +571,22 @@ You are a Task Planner for an AI agent team. Your job is to help the user \
 create a clear, complete task specification before it's sent to the Architect \
 agent for blueprint generation.
 
-You do not call tools directly. However, when the user references a GitHub \
-issue or PR (e.g. "fix #42", "review issue #113"), the orchestrator \
-deterministically pre-fetches the issue/PR body and injects it as a \
-message labelled "=== PRE-FETCHED GITHUB CONTEXT ===" below. Treat that \
-block as authoritative source material — never tell the user you cannot \
-access GitHub when that block is present; summarise its contents and move \
-the task forward.
+You have read-only access to the workspace filesystem via tools \
+(filesystem_list, filesystem_read) and may also have github_read_diff. \
+Use these tools whenever doing so would avoid asking the user a question \
+you can answer yourself — e.g. finding a file path, confirming a \
+framework, or reading a config/package manifest to understand the stack. \
+Do NOT ask the user for information the filesystem can tell you. Use \
+tools sparingly and with purpose — one or two quick lookups per turn is \
+typical; do not exhaustively crawl the repo. If tools aren't available \
+this turn (no provider configured), fall back to asking the user.
+
+When the user references a GitHub issue or PR (e.g. "fix #42", "review \
+issue #113"), the orchestrator deterministically pre-fetches the issue/PR \
+body and injects it as a message labelled "=== PRE-FETCHED GITHUB CONTEXT \
+===" below. Treat that block as authoritative source material — never \
+tell the user you cannot access GitHub when that block is present; \
+summarise its contents and move the task forward.
 
 CRITICAL anti-hallucination rule: if NO "=== PRE-FETCHED GITHUB CONTEXT ===" \
 block is present below, the pre-fetch did not run (missing token, wrong \
@@ -917,9 +934,14 @@ async def send_planner_message(
     # Build messages for LLM
     llm_messages = _build_planner_messages(session)
 
+    # Read-only tools scoped to this session's workspace. Best-effort —
+    # returns [] when no provider is configured, letting the Planner
+    # gracefully degrade to the no-tool path for CLI/test scenarios.
+    tools = _get_planner_readonly_tools(session.task_spec.workspace)
+
     # Call the Planner LLM
     model_name = _get_planner_model_name()
-    response_text = await _call_planner_llm(model_name, llm_messages)
+    response_text = await _call_planner_llm(model_name, llm_messages, tools=tools)
 
     # Extract and apply TaskSpec updates
     updates = _extract_task_spec_updates(response_text)
@@ -969,22 +991,105 @@ async def send_planner_message(
     )
 
 
+def _get_planner_readonly_tools(workspace: str) -> list:
+    """Best-effort: build the read-only tool set scoped to the session's
+    workspace. Returns [] on any failure (no mcp-config.json, provider
+    init error, filtered set empty) — the Planner still works via the
+    GitHub pre-fetch alone, just without filesystem visibility.
+    """
+    if not workspace:
+        return []
+    try:
+        # Imported here to avoid a top-level dependency cycle — the tools
+        # module pulls in provider + bridge, which aren't needed when
+        # Planner is used in isolation (tests, CLI smoke).
+        from ..tools import create_provider, load_mcp_config
+        from ..tools.mcp_bridge import READONLY_TOOLS, get_tools
+        from ..orchestrator import _get_mcp_config_path
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[PLANNER] Tool imports failed: %s", exc)
+        return []
+
+    try:
+        config_path = _get_mcp_config_path()
+        if not config_path.is_file():
+            return []
+        mcp_config = load_mcp_config(str(config_path))
+        provider = create_provider(mcp_config, workspace)
+        tools = get_tools(provider, tool_filter=READONLY_TOOLS)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug(
+            "[PLANNER] Tool provider init failed for workspace %s: %s",
+            workspace, exc,
+        )
+        return []
+
+    return list(tools)
+
+
 async def _call_planner_llm(
     model_name: str,
     messages: list[dict[str, str]],
+    tools: list | None = None,
 ) -> str:
-    """Call the Planner LLM. Supports Gemini and Anthropic models.
+    """Call the Planner LLM, optionally with a read-only tool loop.
 
-    This function is intentionally simple — no tools, no streaming.
-    The Planner is a lightweight validation agent, not a code generator.
+    When ``tools`` is non-empty, the LLM is given ``bind_tools(tools)``
+    and a bounded tool-calling loop (``MAX_PLANNER_TOOL_TURNS`` turns)
+    so the Planner can look up file paths / read configs without
+    asking the user. When empty, falls back to a single no-tool call.
     """
     if model_name.startswith("gemini"):
-        return await _call_gemini(model_name, messages)
+        return await _call_gemini(model_name, messages, tools=tools)
     elif model_name.startswith("claude"):
-        return await _call_anthropic(model_name, messages)
+        return await _call_anthropic(model_name, messages, tools=tools)
     else:
         # Fallback: try langchain-community ChatModel
-        return await _call_langchain_generic(model_name, messages)
+        return await _call_langchain_generic(model_name, messages, tools=tools)
+
+
+async def _invoke_with_optional_tools(
+    llm,
+    lc_messages: list,
+    tools: list | None,
+) -> str:
+    """Shared helper: run the LLM with or without a tool loop.
+
+    Centralizes the tool-loop logic so all three LLM call paths
+    (Gemini, Anthropic, generic) behave identically when tools are
+    available. Best-effort — if the loop raises, logs and falls back
+    to a single tool-free ainvoke.
+    """
+    if not tools:
+        response = await llm.ainvoke(lc_messages)
+        return _extract_text_from_content(response.content)
+
+    try:
+        from ..orchestrator import _run_tool_loop
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[PLANNER] Could not import tool loop: %s", exc)
+        response = await llm.ainvoke(lc_messages)
+        return _extract_text_from_content(response.content)
+
+    try:
+        llm_with_tools = llm.bind_tools(tools)
+        response, _tokens, _log = await _run_tool_loop(
+            llm_with_tools,
+            lc_messages,
+            tools,
+            max_turns=MAX_PLANNER_TOOL_TURNS,
+            tokens_used=0,
+            trace=[],
+            agent_name="planner",
+        )
+        return _extract_text_from_content(response.content)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "[PLANNER] Tool loop failed (%s); falling back to no-tool call",
+            exc,
+        )
+        response = await llm.ainvoke(lc_messages)
+        return _extract_text_from_content(response.content)
 
 
 def _extract_text_from_content(content: Any) -> str:
@@ -1020,8 +1125,9 @@ def _extract_text_from_content(content: Any) -> str:
 async def _call_gemini(
     model_name: str,
     messages: list[dict[str, str]],
+    tools: list | None = None,
 ) -> str:
-    """Call Google Gemini via langchain-google-genai."""
+    """Call Google Gemini via langchain-google-genai, optionally with tools."""
     from langchain_google_genai import ChatGoogleGenerativeAI
 
     llm = ChatGoogleGenerativeAI(
@@ -1030,15 +1136,15 @@ async def _call_gemini(
         max_output_tokens=1024,
     )
     lc_messages = _to_langchain_messages(messages)
-    response = await llm.ainvoke(lc_messages)
-    return _extract_text_from_content(response.content)
+    return await _invoke_with_optional_tools(llm, lc_messages, tools)
 
 
 async def _call_anthropic(
     model_name: str,
     messages: list[dict[str, str]],
+    tools: list | None = None,
 ) -> str:
-    """Call Anthropic Claude via langchain-anthropic."""
+    """Call Anthropic Claude via langchain-anthropic, optionally with tools."""
     from langchain_anthropic import ChatAnthropic
 
     llm = ChatAnthropic(
@@ -1047,15 +1153,15 @@ async def _call_anthropic(
         max_tokens=1024,
     )
     lc_messages = _to_langchain_messages(messages)
-    response = await llm.ainvoke(lc_messages)
-    return _extract_text_from_content(response.content)
+    return await _invoke_with_optional_tools(llm, lc_messages, tools)
 
 
 async def _call_langchain_generic(
     model_name: str,
     messages: list[dict[str, str]],
+    tools: list | None = None,
 ) -> str:
-    """Fallback: attempt via langchain ChatOpenAI (OpenAI-compatible)."""
+    """Fallback: attempt via langchain ChatOpenAI, optionally with tools."""
     from langchain_openai import ChatOpenAI
 
     llm = ChatOpenAI(
@@ -1064,8 +1170,7 @@ async def _call_langchain_generic(
         max_tokens=1024,
     )
     lc_messages = _to_langchain_messages(messages)
-    response = await llm.ainvoke(lc_messages)
-    return _extract_text_from_content(response.content)
+    return await _invoke_with_optional_tools(llm, lc_messages, tools)
 
 
 def _to_langchain_messages(

--- a/dev-suite/tests/test_planner.py
+++ b/dev-suite/tests/test_planner.py
@@ -600,7 +600,7 @@ class TestPlannerGitHubPrefetch:
         async def fake_fetch(*args, **kwargs):
             return [fetched]
 
-        async def fake_llm(model_name, messages):
+        async def fake_llm(model_name, messages, **kwargs):
             # Capture the messages the LLM would have received
             captured_messages.append(messages)
             return '```json\n{"objective": "Fix login"}\n```'
@@ -645,7 +645,7 @@ class TestPlannerGitHubPrefetch:
             fetch_called = True
             return []
 
-        async def fake_llm(model_name, messages):
+        async def fake_llm(model_name, messages, **kwargs):
             return '```json\n{"objective": "Fix login"}\n```'
 
         with patch(
@@ -681,7 +681,7 @@ class TestPlannerGitHubPrefetch:
         async def fake_fetch(*args, **kwargs):
             return [fetched]
 
-        async def fake_llm(model_name, messages):
+        async def fake_llm(model_name, messages, **kwargs):
             return '```json\n{}\n```'
 
         with patch(
@@ -727,7 +727,7 @@ class TestPlannerGitHubPrefetch:
         async def boom(*args, **kwargs):
             raise RuntimeError("network down")
 
-        async def fake_llm(model_name, messages):
+        async def fake_llm(model_name, messages, **kwargs):
             return '```json\n{"objective": "Fix"}\n```'
 
         with patch(
@@ -785,7 +785,7 @@ class TestPlannerSystemPromptReconciliation:
         async def fake_fetch(*args, **kwargs):
             return [fetched]
 
-        async def fake_llm(model_name, messages):
+        async def fake_llm(model_name, messages, **kwargs):
             captured.append(messages)
             return '```json\n{"objective": "Fix the planner"}\n```'
 
@@ -861,7 +861,7 @@ class TestPlannerSystemPromptReconciliation:
 
         session = create_planner_session(workspace="/proj", languages=["Python"])
 
-        async def fake_llm(model_name, messages):
+        async def fake_llm(model_name, messages, **kwargs):
             return '```json\n{}\n```'
 
         with caplog.at_level(_logging.WARNING, logger="src.agents.planner"):
@@ -1031,7 +1031,7 @@ class TestPlannerGithubRepoPlumbing:
                 "source": "github_issue",
             }]
 
-        async def fake_llm(model_name, messages):
+        async def fake_llm(model_name, messages, **kwargs):
             return '```json\n{}\n```'
 
         with patch(
@@ -1072,7 +1072,7 @@ class TestPlannerGithubRepoPlumbing:
             captured_kwargs.update(kwargs)
             return []
 
-        async def fake_llm(model_name, messages):
+        async def fake_llm(model_name, messages, **kwargs):
             return '```json\n{}\n```'
 
         with patch(
@@ -1105,7 +1105,7 @@ class TestPlannerGithubRepoPlumbing:
         session = create_planner_session(workspace=str(tmp_path))
         assert session.github_repo is None
 
-        async def fake_llm(model_name, messages):
+        async def fake_llm(model_name, messages, **kwargs):
             return '```json\n{}\n```'
 
         with caplog.at_level(_logging.WARNING, logger="src.agents.planner"):
@@ -1143,3 +1143,174 @@ class TestPlannerAntiHallucination:
         # Explicitly forbids invention
         assert "must not invent" in prompt or "must not" in prompt
         assert "invent" in prompt or "guess" in prompt
+
+
+# =========================================================================
+# Planner read-only filesystem tool access
+# =========================================================================
+
+
+class TestPlannerReadOnlyTools:
+    """The Planner gets the same READONLY_TOOLS bound to its LLM as the
+    Architect's Phase 2 — so it can look up file paths / read configs
+    itself instead of asking the user, matching the Architect's reach.
+    """
+
+    def test_system_prompt_advertises_filesystem_tools(self):
+        """The system prompt must tell the LLM it can use tools so it
+        actually uses them instead of asking the user for file paths.
+        """
+        from src.agents.planner import _PLANNER_SYSTEM_PROMPT
+
+        prompt = _PLANNER_SYSTEM_PROMPT.lower()
+        assert "filesystem_list" in prompt
+        assert "filesystem_read" in prompt
+        # Pushes the LLM toward using the tools rather than asking
+        assert "do not ask the user" in prompt or "avoid asking" in prompt
+
+    def test_get_planner_readonly_tools_returns_empty_on_no_workspace(self):
+        """No workspace → no tools (nothing to scope a provider to)."""
+        from src.agents.planner import _get_planner_readonly_tools
+
+        assert _get_planner_readonly_tools("") == []
+        assert _get_planner_readonly_tools(None) == []  # type: ignore[arg-type]
+
+    def test_get_planner_readonly_tools_returns_empty_on_missing_config(
+        self, tmp_path, monkeypatch,
+    ):
+        """No mcp-config.json → graceful fallback to zero tools."""
+        from src.agents.planner import _get_planner_readonly_tools
+
+        # Point MCP config at a nonexistent file
+        monkeypatch.setenv("MCP_CONFIG_PATH", str(tmp_path / "nope.json"))
+        assert _get_planner_readonly_tools(str(tmp_path)) == []
+
+    def test_get_planner_readonly_tools_passes_readonly_filter(
+        self, tmp_path, monkeypatch,
+    ):
+        """The helper must call get_tools with tool_filter=READONLY_TOOLS
+        so write tools never reach the Planner LLM. Mocks the provider
+        stack so we assert the contract, not the provider internals.
+        """
+        from unittest.mock import MagicMock
+
+        from src.agents.planner import _get_planner_readonly_tools
+        from src.tools.mcp_bridge import READONLY_TOOLS
+
+        cfg = tmp_path / "mcp-config.json"
+        cfg.write_text('{"servers": {}}', encoding="utf-8")
+        monkeypatch.setenv("MCP_CONFIG_PATH", str(cfg))
+
+        fake_tools = [MagicMock(name="filesystem_read")]
+        get_tools_mock = MagicMock(return_value=fake_tools)
+
+        with patch("src.tools.mcp_bridge.get_tools", get_tools_mock), \
+             patch("src.tools.create_provider", MagicMock()), \
+             patch("src.tools.load_mcp_config", MagicMock()):
+            tools = _get_planner_readonly_tools(str(tmp_path))
+
+        assert tools == fake_tools
+        # The critical assertion: filter was passed so writes cannot leak
+        assert get_tools_mock.called
+        _, kwargs = get_tools_mock.call_args
+        assert kwargs.get("tool_filter") is READONLY_TOOLS
+
+    @pytest.mark.asyncio
+    async def test_send_planner_message_passes_tools_to_llm(
+        self, tmp_path, monkeypatch,
+    ):
+        """send_planner_message fetches tools and forwards them to the
+        LLM call path — even if there are none, the kwarg is passed.
+        """
+        from src.agents.planner import create_planner_session, send_planner_message
+
+        captured_kwargs: dict = {}
+
+        async def fake_llm(model_name, messages, **kwargs):
+            captured_kwargs.update(kwargs)
+            return '```json\n{}\n```'
+
+        session = create_planner_session(workspace=str(tmp_path))
+
+        with patch(
+            "src.agents.planner._call_planner_llm",
+            side_effect=fake_llm,
+        ):
+            await send_planner_message(session, "Add auth middleware")
+
+        # tools kwarg was forwarded (value is [] when no provider —
+        # proves the wire is in place without needing a real provider).
+        assert "tools" in captured_kwargs
+        assert isinstance(captured_kwargs["tools"], list)
+
+    @pytest.mark.asyncio
+    async def test_invoke_with_optional_tools_bypasses_loop_when_no_tools(
+        self,
+    ):
+        """When tools=[] or None, skip bind_tools + loop and call the
+        LLM once directly. Zero added latency for no-tool scenarios.
+        """
+        from src.agents.planner import _invoke_with_optional_tools
+
+        llm = AsyncMock()
+        llm.bind_tools = AsyncMock()  # should NOT be called
+        mock_response = AsyncMock()
+        mock_response.content = "plain response"
+        llm.ainvoke = AsyncMock(return_value=mock_response)
+
+        result = await _invoke_with_optional_tools(llm, [], tools=None)
+        assert result == "plain response"
+        llm.bind_tools.assert_not_called()
+        llm.ainvoke.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_invoke_with_optional_tools_runs_loop_when_tools_present(
+        self, monkeypatch,
+    ):
+        """When tools are provided, bind_tools + _run_tool_loop runs."""
+        from src.agents.planner import _invoke_with_optional_tools
+
+        # Mock the imported _run_tool_loop so we don't need a real LLM
+        async def fake_loop(llm_with_tools, messages, tools, **kwargs):
+            mock_resp = AsyncMock()
+            mock_resp.content = "loop response"
+            return mock_resp, 0, []
+
+        monkeypatch.setattr(
+            "src.orchestrator._run_tool_loop", fake_loop,
+        )
+
+        llm = AsyncMock()
+        bound_llm = AsyncMock()
+        llm.bind_tools = lambda _tools: bound_llm  # sync method
+
+        fake_tools = [AsyncMock(name="fake_tool_obj")]
+        result = await _invoke_with_optional_tools(llm, [], tools=fake_tools)
+        assert result == "loop response"
+
+    @pytest.mark.asyncio
+    async def test_invoke_with_optional_tools_falls_back_on_loop_error(
+        self, monkeypatch,
+    ):
+        """If the tool loop raises, fall back to a single no-tool call
+        so the Planner turn still completes (graceful degradation).
+        """
+        from src.agents.planner import _invoke_with_optional_tools
+
+        async def exploding_loop(*args, **kwargs):
+            raise RuntimeError("provider crashed")
+
+        monkeypatch.setattr(
+            "src.orchestrator._run_tool_loop", exploding_loop,
+        )
+
+        llm = AsyncMock()
+        llm.bind_tools = lambda _tools: llm
+        fallback_response = AsyncMock()
+        fallback_response.content = "fallback response"
+        llm.ainvoke = AsyncMock(return_value=fallback_response)
+
+        fake_tools = [AsyncMock(name="fake_tool_obj")]
+        result = await _invoke_with_optional_tools(llm, [], tools=fake_tools)
+        assert result == "fallback response"
+        llm.ainvoke.assert_awaited()


### PR DESCRIPTION
## Summary

The Planner was shipping noisy clarifications like *"what's the exact `BottomPanel` file path?"* and *"is this a SvelteKit project?"* — questions it could answer itself by running `filesystem_list` / `filesystem_read` against the workspace. The Architect already gets these via its Phase 2 escalation; the Planner should have the same reach.

### Changes

- **`_get_planner_readonly_tools(workspace)`** — scopes a local `ToolProvider` to the session's workspace, filters to `READONLY_TOOLS` (`filesystem_list`, `filesystem_read`, `github_read_diff`). Returns `[]` on any error so CLI / tests keep working.
- **`_invoke_with_optional_tools(llm, messages, tools)`** — central tool-loop plumbing shared by Gemini / Anthropic / generic callers. `tools=None|[]` → single no-tool `ainvoke` (zero added latency). Tools present → `bind_tools` + bounded tool loop (`MAX_PLANNER_TOOL_TURNS`, default 4, matching Architect Phase 2). Loop raising falls back to a single no-tool call.
- `_call_planner_llm`, `_call_gemini`, `_call_anthropic`, `_call_langchain_generic` all take an optional `tools` kwarg.
- `send_planner_message` fetches tools for the session's workspace and forwards them.
- System prompt advertises `filesystem_list` / `filesystem_read` and explicitly tells the LLM *"do not ask the user for information the filesystem can tell you."*

Reuses the Architect Phase 2 infrastructure (`_run_tool_loop`, tool execution, token accounting) — no duplication.

### Safety posture

- `READONLY_TOOLS` filter is applied at `get_tools()` — write tools cannot reach the Planner
- Tool loop bounded by `MAX_PLANNER_TOOL_TURNS=4` (overridable via env)
- Any failure in provider init or the loop degrades gracefully to the pre-PR no-tool behaviour

## Test plan

- [x] `uv run pytest tests/test_planner.py tests/test_github_fetch.py tests/test_mcp_tools.py tests/test_architect_two_phase.py tests/test_api.py` — 287/287 pass
- [x] 8 new tests in `TestPlannerReadOnlyTools`: prompt advertises tools, helper returns `[]` without workspace/config, `READONLY_TOOLS` filter is passed to `get_tools`, `send_planner_message` forwards the kwarg, tool-loop bypass when no tools, tool-loop runs when tools present, graceful fallback on loop error
- [ ] Post-merge manual smoke: *"Review and implement the fix for GitHub Issue #113"* — Planner should resolve `BottomPanel.svelte` path itself via `filesystem_list` instead of asking the user

Refs #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)