### PR TITLE
fix(planner): thread real tool results into wrap-up + raise cap to 50 + rich logging

### DIFF
--- a/dev-suite/src/agents/planner.py
+++ b/dev-suite/src/agents/planner.py
@@ -56,13 +56,17 @@ SESSION_TTL_SECONDS = 30 * 60
 # the context injection bounded if the user pastes a long list of refs.
 PLANNER_MAX_GITHUB_REFS = 5
 
-# Planner read-only tool loop turn cap. Matches the Architect's Phase 2
-# budget — enough turns for a few ls/read calls to orient the spec,
-# bounded so a misbehaving LLM can't drain tokens chasing the codebase.
+# Planner read-only tool loop turn cap. Intentionally generous — the
+# cap exists as a safety net against runaway loops, not as a cost shape.
+# Real tasks have been observed taking 6+ calls for well-documented
+# issues and 10-20+ for complex ones. 50 is high enough that realistic
+# work will never hit it and low enough that a pathological infinite
+# loop still terminates in bounded wall time. Tune via the env var if
+# the default proves too low or too high — we'll adjust as we get data.
 try:
-    MAX_PLANNER_TOOL_TURNS = int(os.getenv("MAX_PLANNER_TOOL_TURNS", "6"))
+    MAX_PLANNER_TOOL_TURNS = int(os.getenv("MAX_PLANNER_TOOL_TURNS", "50"))
 except ValueError:
-    MAX_PLANNER_TOOL_TURNS = 6
+    MAX_PLANNER_TOOL_TURNS = 50
 
 # Issue #193: loose heuristic for "the user mentioned a `#N` ref but we
 # couldn't resolve it." Used only for warning diagnostics when the
@@ -939,8 +943,22 @@ async def send_planner_message(
     # gracefully degrade to the no-tool path for CLI/test scenarios.
     tools = _get_planner_readonly_tools(session.task_spec.workspace)
 
-    # Call the Planner LLM
+    # Turn-start diagnostic log. Gives us a single line to correlate
+    # subsequent tool-loop output against — session id, model, workspace,
+    # how many read-only tools loaded, and the user message preview.
     model_name = _get_planner_model_name()
+    logger.info(
+        "[PLANNER] turn start: session=%s model=%s workspace=%s "
+        "tools_loaded=%d github_context=%d user_msg=%s",
+        session.session_id,
+        model_name,
+        session.task_spec.workspace or "<unset>",
+        len(tools),
+        len(session.task_spec.github_context),
+        (user_message[:120] + "...") if len(user_message) > 120 else user_message,
+    )
+
+    # Call the Planner LLM
     response_text = await _call_planner_llm(model_name, llm_messages, tools=tools)
 
     # Extract and apply TaskSpec updates
@@ -998,6 +1016,9 @@ def _get_planner_readonly_tools(workspace: str) -> list:
     GitHub pre-fetch alone, just without filesystem visibility.
     """
     if not workspace:
+        logger.info(
+            "[PLANNER] No workspace set; skipping tool provider init"
+        )
         return []
     try:
         # Imported here to avoid a top-level dependency cycle — the tools
@@ -1007,18 +1028,22 @@ def _get_planner_readonly_tools(workspace: str) -> list:
         from ..tools import create_provider, load_mcp_config
         from ..tools.mcp_bridge import READONLY_TOOLS, get_tools
     except Exception as exc:  # noqa: BLE001
-        logger.debug("[PLANNER] Tool imports failed: %s", exc)
+        logger.info("[PLANNER] Tool imports failed: %s", exc)
         return []
 
     try:
         config_path = _get_mcp_config_path()
         if not config_path.is_file():
+            logger.info(
+                "[PLANNER] No mcp-config.json at %s; tools disabled",
+                config_path,
+            )
             return []
         mcp_config = load_mcp_config(str(config_path))
         provider = create_provider(mcp_config, workspace)
         tools = get_tools(provider, tool_filter=READONLY_TOOLS)
     except Exception as exc:  # noqa: BLE001
-        logger.debug(
+        logger.info(
             "[PLANNER] Tool provider init failed for workspace %s: %s",
             workspace, exc,
         )
@@ -1073,7 +1098,7 @@ async def _invoke_with_optional_tools(
 
     try:
         llm_with_tools = llm.bind_tools(tools)
-        response, _tokens, _log = await _run_tool_loop(
+        response, _tokens, _log, loop_messages = await _run_tool_loop(
             llm_with_tools,
             lc_messages,
             tools,
@@ -1081,24 +1106,61 @@ async def _invoke_with_optional_tools(
             tokens_used=0,
             trace=[],
             agent_name="planner",
+            return_messages=True,
         )
         text = _extract_text_from_content(response.content)
         if text.strip():
             return text
 
-        # Loop exhausted mid-tool-call — response is a pure tool_use
-        # block with no user-facing text. We can't simply replay the
-        # loop's `current_messages` because the final tool_use has no
-        # paired tool_result (Anthropic rejects unpaired sequences),
-        # so fall back to a no-tools call on the ORIGINAL messages.
-        # The LLM loses its mid-loop learnings but produces a valid
-        # conversational response instead of a raw tool_use dump.
-        logger.warning(
-            "[PLANNER] Tool loop exhausted without final text; "
-            "retrying unbound on original messages"
+        # Loop exhausted mid-tool-call — the returned response is a pure
+        # tool_use block with no user-facing text. Build a wrap-up call
+        # that preserves the REAL tool results the loop gathered so the
+        # LLM doesn't have to fabricate. We must drop the unresolved
+        # final assistant message (its tool_use blocks have no paired
+        # tool_result; Anthropic would reject the sequence). Then
+        # append an explicit "no more tools" instruction and a final
+        # user prompt so the conversation ends on a user turn.
+        wrap_up_messages = list(loop_messages)
+        # Drop only the single trailing assistant message if it has
+        # unresolved tool_use blocks. Earlier paired tool_call /
+        # tool_result messages are valid context — we want to keep
+        # them so the wrap-up LLM has real data to summarise. Looping
+        # would erase those pairs too.
+        if _is_unresolved_tail(wrap_up_messages):
+            wrap_up_messages.pop()
+
+        from langchain_core.messages import HumanMessage
+        nudge = (
+            "You've used your tool budget for this turn. Do NOT call or "
+            "simulate any tools. Do NOT write `<tool_call>` tags, JSON "
+            "tool-call syntax, or any tool-invocation-shaped text. "
+            "Using ONLY what you've already learned from the tool "
+            "results above in this conversation, produce the final "
+            "conversational task-spec response per the system prompt, "
+            "including the hidden JSON extraction block at the end. "
+            "If the tool results were insufficient to answer, say so "
+            "plainly and ask the user for the missing information — "
+            "do not invent file paths, frameworks, or content."
         )
-        fallback_response = await llm.ainvoke(lc_messages)
-        return _extract_text_from_content(fallback_response.content)
+        wrap_up_messages.append(HumanMessage(content=nudge))
+
+        logger.info(
+            "[PLANNER] Wrap-up triggered: loop_messages=%d -> wrap_up=%d "
+            "(dropped %d unresolved tail message(s))",
+            len(loop_messages),
+            len(wrap_up_messages),
+            len(loop_messages) - (len(wrap_up_messages) - 1),
+        )
+
+        final_response = await llm.ainvoke(wrap_up_messages)
+        final_text = _extract_text_from_content(final_response.content)
+        if not final_text.strip():
+            logger.warning(
+                "[PLANNER] Wrap-up call also returned empty/non-text "
+                "(content type=%s); falling through to empty reply",
+                type(final_response.content).__name__,
+            )
+        return final_text
     except Exception as exc:  # noqa: BLE001
         logger.warning(
             "[PLANNER] Tool loop failed (%s); falling back to no-tool call",
@@ -1106,6 +1168,33 @@ async def _invoke_with_optional_tools(
         )
         response = await llm.ainvoke(lc_messages)
         return _extract_text_from_content(response.content)
+
+
+def _is_unresolved_tail(messages: list) -> bool:
+    """True if the last message in a sequence is a tool_use-bearing
+    assistant message with no paired tool_result following it, OR a
+    standalone tool_result with no assistant message preceding it.
+    Used to trim the sequence before a wrap-up call so the message
+    history is valid for Anthropic's paired-block requirement.
+    """
+    if not messages:
+        return False
+    from langchain_core.messages import AIMessage, ToolMessage
+    last = messages[-1]
+    if isinstance(last, ToolMessage):
+        # Rare: ends on a tool result with nothing consuming it.
+        # Safe to drop.
+        return True
+    if isinstance(last, AIMessage):
+        content = getattr(last, "content", None)
+        tool_calls = getattr(last, "tool_calls", None) or []
+        if tool_calls:
+            return True
+        if isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "tool_use":
+                    return True
+    return False
 
 
 def _extract_text_from_content(content: Any) -> str:

--- a/dev-suite/src/orchestrator.py
+++ b/dev-suite/src/orchestrator.py
@@ -363,6 +363,12 @@ async def _execute_tool_call(tool_call, tools):
     tool = tool_map.get(tool_name)
     if not tool:
         return ToolMessage(content=f"Error: Tool '{tool_name}' not found. Available: {list(tool_map.keys())}", tool_call_id=tool_id)
+    # Pre-call log so we can see the call even if it hangs.
+    logger.info(
+        "[TOOLS] exec %s args=%s",
+        tool_name,
+        _sanitize_preview(str(tool_args))[:200],
+    )
     try:
         if hasattr(tool, "ainvoke"):
             result = await tool.ainvoke(tool_args)
@@ -370,37 +376,124 @@ async def _execute_tool_call(tool_call, tools):
             result = tool.invoke(tool_args)
         return ToolMessage(content=str(result), tool_call_id=tool_id)
     except Exception as e:
-        logger.warning("[TOOLS] Tool %s failed: %s", tool_name, e)
+        logger.warning(
+            "[TOOLS] Tool %s failed: %s (args=%s)",
+            tool_name, e,
+            _sanitize_preview(str(tool_args))[:200],
+        )
         return ToolMessage(content=f"Error executing {tool_name}: {type(e).__name__}: {e}", tool_call_id=tool_id)
 
 
-async def _run_tool_loop(llm_with_tools, messages, tools, max_turns=MAX_TOOL_TURNS, tokens_used=0, trace=None, agent_name="agent"):
+async def _run_tool_loop(
+    llm_with_tools,
+    messages,
+    tools,
+    max_turns=MAX_TOOL_TURNS,
+    tokens_used=0,
+    trace=None,
+    agent_name="agent",
+    return_messages=False,
+):
+    """Run an LLM tool-calling loop until the model stops calling tools
+    or ``max_turns`` is reached.
+
+    By default returns a 3-tuple ``(response, tokens_used, tool_calls_log)``
+    for backwards compatibility with the Architect / Developer / QA call
+    sites. When ``return_messages=True``, returns a 4-tuple with the
+    accumulated ``current_messages`` as the trailing element — needed by
+    the Planner's wrap-up path, which threads real tool results into a
+    fallback unbound call when the loop exhausts mid-tool-use.
+    """
+    import time as _time
+
     if trace is None:
         trace = []
     tool_calls_log = []
     current_messages = list(messages)
+    agent_upper = agent_name.upper()
+
+    def _wrap(value):
+        if return_messages:
+            return value[0], value[1], value[2], current_messages
+        return value
+
     if max_turns <= 0:
-        logger.warning("[%s] max_turns=%d, skipping tool loop", agent_name.upper(), max_turns)
+        logger.warning("[%s] max_turns=%d, skipping tool loop", agent_upper, max_turns)
         trace.append(f"{agent_name}: tool loop skipped (max_turns={max_turns})")
         last_msg = current_messages[-1] if current_messages else AIMessage(content="")
-        return last_msg, tokens_used, tool_calls_log
+        return _wrap((last_msg, tokens_used, tool_calls_log))
     for turn in range(max_turns):
         response = await llm_with_tools.ainvoke(current_messages)
         tokens_used += _extract_token_count(response)
         tool_calls = getattr(response, "tool_calls", None) or []
         if not tool_calls:
             trace.append(f"{agent_name}: tool loop done after {turn} tool turn(s)")
-            return response, tokens_used, tool_calls_log
+            logger.info(
+                "[%s] Tool loop done after %d turn(s); total calls=%d",
+                agent_upper, turn, len(tool_calls_log),
+            )
+            return _wrap((response, tokens_used, tool_calls_log))
         trace.append(f"{agent_name}: turn {turn + 1} -- {len(tool_calls)} tool call(s): {', '.join(tc.get('name', '?') for tc in tool_calls)}")
-        logger.info("[%s] Tool turn %d: %d calls", agent_name.upper(), turn + 1, len(tool_calls))
+        logger.info(
+            "[%s] turn %d/%d: %d tool call(s)",
+            agent_upper, turn + 1, max_turns, len(tool_calls),
+        )
         current_messages.append(response)
         for tc in tool_calls:
+            tc_name = tc.get("name", "unknown")
+            tc_args = tc.get("args", {})
+            started = _time.perf_counter()
             tool_msg = await _execute_tool_call(tc, tools)
+            elapsed_ms = int((_time.perf_counter() - started) * 1000)
             current_messages.append(tool_msg)
-            tool_calls_log.append({"agent": agent_name, "turn": turn + 1, "tool": tc.get("name", "unknown"), "args_preview": _sanitize_preview(str(tc.get("args", {}))), "result_preview": _sanitize_preview(str(tool_msg.content)), "success": not tool_msg.content.startswith("Error")})
+            result_str = str(tool_msg.content)
+            success = not result_str.startswith("Error")
+            tool_calls_log.append({
+                "agent": agent_name,
+                "turn": turn + 1,
+                "tool": tc_name,
+                "args_preview": _sanitize_preview(str(tc_args)),
+                "result_preview": _sanitize_preview(result_str),
+                "success": success,
+            })
+            logger.info(
+                "[%s] turn %d/%d: %s(%s) -> %d chars in %dms [%s]",
+                agent_upper, turn + 1, max_turns,
+                tc_name,
+                _sanitize_preview(str(tc_args))[:200],
+                len(result_str), elapsed_ms,
+                "ok" if success else "error",
+            )
+
+    # Exhaustion — compile a compact summary so "why did it exhaust?"
+    # is answerable from the log alone.
+    per_tool_counts: dict[str, int] = {}
+    failure_count = 0
+    for entry in tool_calls_log:
+        per_tool_counts[entry["tool"]] = per_tool_counts.get(entry["tool"], 0) + 1
+        if not entry["success"]:
+            failure_count += 1
+    block_types: list[str] = []
+    content = getattr(response, "content", None)
+    if isinstance(content, list):
+        for block in content:
+            if isinstance(block, dict):
+                block_types.append(block.get("type", "?"))
+            else:
+                block_types.append(type(block).__name__)
+    elif isinstance(content, str):
+        block_types = ["str"]
+    counts_preview = ", ".join(f"{k}={v}" for k, v in per_tool_counts.items())
     trace.append(f"{agent_name}: tool loop hit max turns ({max_turns})")
-    logger.warning("[%s] Hit max tool turns (%d)", agent_name.upper(), max_turns)
-    return response, tokens_used, tool_calls_log
+    logger.warning(
+        "[%s] Hit max tool turns (%d). Total calls: %d (%s). Failures: %d. "
+        "Final response block types: %s",
+        agent_upper, max_turns, len(tool_calls_log),
+        counts_preview or "none",
+        failure_count,
+        block_types or "empty",
+    )
+    return _wrap((response, tokens_used, tool_calls_log))
 
 
 def _run_async(coro):

--- a/dev-suite/tests/test_planner.py
+++ b/dev-suite/tests/test_planner.py
@@ -1267,14 +1267,22 @@ class TestPlannerReadOnlyTools:
     async def test_invoke_with_optional_tools_runs_loop_when_tools_present(
         self, monkeypatch,
     ):
-        """When tools are provided, bind_tools + _run_tool_loop runs."""
+        """When tools are provided, bind_tools + _run_tool_loop runs.
+
+        The Planner opts into return_messages=True so the loop returns a
+        4-tuple (response, tokens, log, messages). When the final
+        response already has text, we just return it — no wrap-up.
+        """
         from src.agents.planner import _invoke_with_optional_tools
 
-        # Mock the imported _run_tool_loop so we don't need a real LLM
         async def fake_loop(llm_with_tools, messages, tools, **kwargs):
+            assert kwargs.get("return_messages") is True, (
+                "Planner must opt into return_messages so the wrap-up "
+                "can thread real tool results on exhaustion."
+            )
             mock_resp = AsyncMock()
             mock_resp.content = "loop response"
-            return mock_resp, 0, []
+            return mock_resp, 0, [], list(messages)
 
         monkeypatch.setattr(
             "src.orchestrator._run_tool_loop", fake_loop,
@@ -1316,49 +1324,175 @@ class TestPlannerReadOnlyTools:
         llm.ainvoke.assert_awaited()
 
     @pytest.mark.asyncio
-    async def test_invoke_with_optional_tools_wraps_up_on_exhaustion(
+    async def test_wrap_up_threads_real_loop_messages_not_originals(
         self, monkeypatch,
     ):
-        """Max-turns regression: if the loop returns a pure tool_use
-        response with no text, we retry the unbound LLM on the original
-        messages so the user sees prose instead of a raw dict dump.
-        Repro for: `Hit max tool turns (4)` + "Unexpected LLM response
-        content type: list" from the initial PR #200 smoke test.
+        """Hallucination regression from the PR #201 smoke: wrap-up used
+        to call the unbound LLM with only the ORIGINAL system+user
+        messages, so the LLM had zero real filesystem info and
+        fabricated paths (`BottomPanel.jsx`) + `<tool_call>` XML.
+
+        Fix: pass the loop's accumulated messages (real tool results +
+        assistant responses) to the wrap-up so the LLM has grounded
+        context.
         """
+        from langchain_core.messages import (
+            AIMessage,
+            HumanMessage,
+            SystemMessage,
+            ToolMessage,
+        )
+
         from src.agents.planner import _invoke_with_optional_tools
 
-        # _run_tool_loop returns a tool_use-only response — what
-        # Anthropic sends mid-call when max turns hits.
-        exhausted_response = AsyncMock()
-        exhausted_response.content = [
+        original_messages = [
+            SystemMessage(content="You are the Planner..."),
+            HumanMessage(content="Fix issue #113"),
+        ]
+
+        # Simulate what _run_tool_loop accumulated: original + 1 tool
+        # call round-trip + final unresolved tool_use.
+        fake_tool_call_msg = AIMessage(
+            content="",
+            tool_calls=[{
+                "id": "call_1",
+                "name": "filesystem_list",
+                "args": {"path": "dashboard/src/lib"},
+            }],
+        )
+        fake_tool_result_msg = ToolMessage(
+            content="components/\nrouter/\nstores/",
+            tool_call_id="call_1",
+        )
+        # The real loop returns a LangChain AIMessage — using a raw
+        # AsyncMock here would sneak past the isinstance check in
+        # `_is_unresolved_tail` and never get dropped, masking the bug.
+        exhausted_response = AIMessage(content=[
             {
-                "id": "toolu_01GxiJrS8Xj4jN4FeFT3vsJu",
-                "input": {"__arg1": "dashboard/src/lib"},
+                "id": "toolu_xyz",
+                "input": {"__arg1": "dashboard/src/lib/components"},
                 "name": "filesystem_list",
                 "type": "tool_use",
             },
+        ])
+        loop_final_messages = [
+            *original_messages,
+            fake_tool_call_msg,
+            fake_tool_result_msg,
+            exhausted_response,  # unresolved tail — must be dropped
         ]
 
-        async def fake_loop(*args, **kwargs):
-            return exhausted_response, 0, []
+        async def fake_loop(llm_with_tools, messages, tools, **kwargs):
+            return exhausted_response, 0, [], loop_final_messages
 
         monkeypatch.setattr("src.orchestrator._run_tool_loop", fake_loop)
 
         wrap_up_response = AsyncMock()
         wrap_up_response.content = (
-            "Here's the task spec based on what I already know..."
+            "Here's the spec — found components/ under dashboard/src/lib"
         )
+        captured_wrap_up_messages: list = []
+
+        async def capturing_ainvoke(messages):
+            captured_wrap_up_messages.extend(messages)
+            return wrap_up_response
+
         llm = AsyncMock()
         llm.bind_tools = lambda _tools: llm
-        llm.ainvoke = AsyncMock(return_value=wrap_up_response)
+        llm.ainvoke = capturing_ainvoke
 
         fake_tools = [AsyncMock(name="filesystem_list")]
-        result = await _invoke_with_optional_tools(llm, [], tools=fake_tools)
-        # User sees prose, not "[{'id': 'toolu_...', ...}]"
-        assert result == "Here's the task spec based on what I already know..."
-        assert "toolu_" not in result
-        assert "tool_use" not in result
-        llm.ainvoke.assert_awaited()  # The wrap-up call fired
+        result = await _invoke_with_optional_tools(
+            llm, original_messages, tools=fake_tools,
+        )
+        assert "components/" in result
+
+        # Real tool result must have reached the wrap-up call.
+        content_strs = [
+            str(getattr(m, "content", "")) for m in captured_wrap_up_messages
+        ]
+        assert any("components/\nrouter/" in c for c in content_strs), (
+            "Wrap-up LLM must see the real tool results, not just the "
+            "original messages — otherwise it fabricates."
+        )
+
+        # Unresolved tool_use tail must NOT be in the wrap-up messages
+        # (Anthropic would reject unpaired tool_use without tool_result).
+        assert exhausted_response not in captured_wrap_up_messages
+
+        # Explicit no-tools instruction must be appended as the final
+        # user message so the conversation ends on a user turn AND the
+        # LLM won't fabricate fake tool calls.
+        last_msg = captured_wrap_up_messages[-1]
+        assert isinstance(last_msg, HumanMessage)
+        nudge_text = str(last_msg.content).lower()
+        assert "do not call" in nudge_text or "not call" in nudge_text
+        assert "tool_call" in nudge_text  # forbids the XML tag the user saw
+        assert "invent" in nudge_text or "fabricate" in nudge_text or \
+               "do not invent" in nudge_text
+
+
+class TestIsUnresolvedTail:
+    """Unit coverage for the helper that detects a trailing assistant
+    message whose tool_use blocks weren't paired with tool_result
+    messages — needed before a wrap-up call so the sequence is valid
+    for Anthropic's paired-block requirement.
+    """
+
+    def test_empty_sequence(self):
+        from src.agents.planner import _is_unresolved_tail
+
+        assert _is_unresolved_tail([]) is False
+
+    def test_plain_assistant_text_is_resolved(self):
+        from langchain_core.messages import AIMessage
+
+        from src.agents.planner import _is_unresolved_tail
+
+        assert _is_unresolved_tail([AIMessage(content="hello")]) is False
+
+    def test_assistant_with_tool_calls_is_unresolved(self):
+        from langchain_core.messages import AIMessage
+
+        from src.agents.planner import _is_unresolved_tail
+
+        msg = AIMessage(
+            content="",
+            tool_calls=[{"id": "x", "name": "fs_list", "args": {}}],
+        )
+        assert _is_unresolved_tail([msg]) is True
+
+    def test_anthropic_tool_use_block_is_unresolved(self):
+        from langchain_core.messages import AIMessage
+
+        from src.agents.planner import _is_unresolved_tail
+
+        msg = AIMessage(content=[
+            {"id": "x", "type": "tool_use", "name": "fs", "input": {}},
+        ])
+        assert _is_unresolved_tail([msg]) is True
+
+    def test_mixed_text_and_tool_use_is_unresolved(self):
+        """If the assistant emitted text + tool_use, the tool_use still
+        needs a paired tool_result; the whole message is unresolved.
+        """
+        from langchain_core.messages import AIMessage
+
+        from src.agents.planner import _is_unresolved_tail
+
+        msg = AIMessage(content=[
+            {"type": "text", "text": "Let me check..."},
+            {"id": "x", "type": "tool_use", "name": "fs", "input": {}},
+        ])
+        assert _is_unresolved_tail([msg]) is True
+
+    def test_trailing_tool_message_is_unresolved(self):
+        from langchain_core.messages import ToolMessage
+
+        from src.agents.planner import _is_unresolved_tail
+
+        msg = ToolMessage(content="result", tool_call_id="x")
+        assert _is_unresolved_tail([msg]) is True
 
 
 class TestExtractTextFromContent:

--- a/dev-suite/tests/test_tool_binding.py
+++ b/dev-suite/tests/test_tool_binding.py
@@ -450,3 +450,62 @@ class TestMaxToolTurns:
         monkeypatch.setenv("MAX_TOOL_TURNS", "5")
         from src.orchestrator import _safe_int
         assert _safe_int("MAX_TOOL_TURNS", 10) == 5
+
+
+class TestRunToolLoopReturnMessages:
+    """The Planner opts into `return_messages=True` so its wrap-up path
+    can thread real tool results into a fallback unbound call. The
+    existing Architect / Developer / QA call sites must stay on the
+    3-tuple — this is the regression guard.
+    """
+
+    @pytest.mark.asyncio
+    async def test_default_returns_three_tuple(self):
+        from langchain_core.messages import AIMessage, HumanMessage
+
+        from src.orchestrator import _run_tool_loop
+
+        # Model returns a final answer on turn 1 (no tool calls).
+        final = AIMessage(content="done")
+        llm = AsyncMock()
+        llm.ainvoke = AsyncMock(return_value=final)
+
+        result = await _run_tool_loop(
+            llm,
+            [HumanMessage(content="go")],
+            tools=[],
+            max_turns=3,
+            agent_name="test",
+        )
+        assert isinstance(result, tuple)
+        assert len(result) == 3
+        response, tokens, log = result
+        assert response is final
+        assert isinstance(tokens, int)
+        assert isinstance(log, list)
+
+    @pytest.mark.asyncio
+    async def test_return_messages_true_returns_four_tuple(self):
+        from langchain_core.messages import AIMessage, HumanMessage
+
+        from src.orchestrator import _run_tool_loop
+
+        final = AIMessage(content="done")
+        llm = AsyncMock()
+        llm.ainvoke = AsyncMock(return_value=final)
+
+        result = await _run_tool_loop(
+            llm,
+            [HumanMessage(content="go")],
+            tools=[],
+            max_turns=3,
+            agent_name="test",
+            return_messages=True,
+        )
+        assert isinstance(result, tuple)
+        assert len(result) == 4
+        response, tokens, log, messages = result
+        assert response is final
+        # Original messages at minimum — loop appends more as it runs.
+        assert len(messages) >= 1
+        assert isinstance(messages, list)


### PR DESCRIPTION
## Summary

Follow-up to #201. The wrap-up strategy there prevented raw `tool_use` dicts from reaching the chat, but threw away all the tool results the loop gathered — so the unbound fallback LLM **fabricated** the answer. Latest smoke claimed `BottomPanel.jsx` + React/Vite when the real project is Svelte + TypeScript, and the prose contained synthetic `<tool_call>{...}</tool_call>` XML tags.

## Three compounding fixes

### 1. `_run_tool_loop` gains `return_messages=False` kwarg

When True, returns a 4-tuple `(response, tokens, log, messages)`. The Architect / Developer / QA call sites stay on the existing 3-tuple; only the Planner opts in.

### 2. Planner wrap-up rewritten to use real context

On exhaustion:
- Take the loop's accumulated `current_messages`
- Drop only the single trailing assistant message with unresolved `tool_use` blocks (Anthropic rejects unpaired sequences) — loop-style trimming would erase earlier paired tool_call/tool_result context
- Append an explicit `HumanMessage` forbidding tool-call simulation: *"Do NOT call or simulate any tools. Do NOT write `<tool_call>` tags, JSON tool-call syntax, or any tool-invocation-shaped text. Using ONLY what you've already learned from the tool results above in this conversation, produce the final conversational task-spec response per the system prompt..."*
- Call the unbound LLM with that valid, truth-containing history

The LLM now has the real filesystem output, not a clean slate.

### 3. `MAX_PLANNER_TOOL_TURNS` default 6 → 50

Per user feedback: even a well-documented issue like #113 took 6+ calls, and complex issues could easily need 10-20. The cap exists as a safety net against runaway loops, not as a cost shape. Env var remains for operator tuning.

## Diagnostic logging — so next time we know exactly what happened

Rich logging at every decision point, so if this doesn't fully fix it, the backend log alone tells us why:

- **Planner turn-start**: `[PLANNER] turn start: session=... model=... workspace=... tools_loaded=N github_context=M user_msg=...`
- **Tool loader failures**: upgraded from `debug` → `info`, each reason logged distinctly (no workspace / missing config / init error)
- **`_run_tool_loop` per tool call**: `[PLANNER] turn 3/50: filesystem_list(path='...') -> 1421 chars in 12ms [ok]`
- **Tool executor**: pre-call log so hung calls are visible; failures include the args that triggered them
- **Loop exhaustion summary**: `[PLANNER] Hit max tool turns (50). Total calls: 52 (filesystem_list=31, filesystem_read=21). Failures: 4. Final response block types: ['tool_use']`
- **Wrap-up entry**: messages-before / messages-after / dropped count
- **Wrap-up empty-response**: warning with content type if even the wrap-up fails

## Test plan

- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run pytest tests/test_planner.py tests/test_tool_binding.py tests/test_architect_two_phase.py tests/test_github_fetch.py tests/test_mcp_tools.py tests/test_api.py` — 347/347 pass
- [x] `uv run pytest tests/ -m "not integration"` — 1135 pass (2 pre-existing unrelated Windows path-separator failures confirmed on `main`)
- New tests:
  - `TestPlannerReadOnlyTools::test_wrap_up_threads_real_loop_messages_not_originals` — repro for the fabrication bug: asserts the wrap-up LLM sees the real tool result, the unresolved tool_use is dropped, and the appended nudge contains "do not call" / "tool_call" / "invent"
  - `TestIsUnresolvedTail` class — 6 unit tests covering empty/plain-text/tool_calls/anthropic-tool_use-block/mixed/trailing-ToolMessage
  - `TestRunToolLoopReturnMessages` in `test_tool_binding.py` — regression guard: default 3-tuple vs `return_messages=True` 4-tuple
- [ ] Post-merge smoke: *"Review and implement the fix for GitHub Issue #113"* — Planner should either (a) finish within 50 turns with a grounded response citing the real `BottomPanel.svelte` path, OR (b) hit wrap-up but the wrap-up response cites real findings with no fabricated `.jsx` / React / `<tool_call>` XML

Refs #193, follow-up to #200 / #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)