### PR TITLE
fix(api): stop forcing re-auth on submit for already-verified protected sessions

### DIFF
--- a/dev-suite/src/agents/planner.py
+++ b/dev-suite/src/agents/planner.py
@@ -215,6 +215,14 @@ class PlannerSession(BaseModel):
     # workspaces. Falls back to GITHUB_OWNER/GITHUB_REPO env vars when
     # both the session value and auto-detect come up empty.
     github_repo: str | None = None
+    # True when the session's workspace was PIN-verified at start time,
+    # i.e. the user cleared the protected-workspace gate. Lets the submit
+    # endpoint distinguish "session was authorized for a workspace that's
+    # still protected" (allow) from "session was never authorized and
+    # workspace is now protected" (reject). Without this flag, every
+    # submit to a protected workspace was forced to re-prompt for the
+    # PIN even when the user had already verified moments earlier.
+    authorized: bool = False
 
     @property
     def is_expired(self) -> bool:
@@ -508,6 +516,7 @@ def create_planner_session(
     languages: list[str] | None = None,
     frameworks: list[str] | None = None,
     github_repo: str | None = None,
+    authorized: bool = False,
 ) -> PlannerSession:
     """Create a new planner session with optional pre-populated fields.
 
@@ -518,6 +527,11 @@ def create_planner_session(
     parsing ``remote.origin.url`` from the workspace's ``.git/config``.
     The resolved repo is used as the default owner/repo when the Planner
     pre-fetches issue/PR refs like "Issue #113" from user messages.
+
+    ``authorized`` should be True when the caller has already cleared
+    the workspace's PIN gate (or the workspace is not protected). It's
+    stored on the session so the submit endpoint doesn't re-prompt for
+    a PIN that's already been verified this session.
     """
     task_spec = TaskSpec(
         workspace=workspace,
@@ -532,6 +546,7 @@ def create_planner_session(
         task_spec=task_spec,
         checklist=checklist,
         github_repo=resolved_repo,
+        authorized=authorized,
     )
 
     # System message with pre-populated context — formatted with clear

--- a/dev-suite/src/api/main.py
+++ b/dev-suite/src/api/main.py
@@ -345,8 +345,14 @@ async def start_planner_session(
             403,
         )
 
-    # Protected workspace check
-    if ws_mgr.is_protected(body.workspace):
+    # Protected workspace check. Track whether the PIN gate cleared so
+    # we can stamp the session as authorized for protected workspaces —
+    # otherwise every submit for a protected workspace would force the
+    # user to restart the session with the PIN again, even though they
+    # just verified it moments earlier.
+    is_protected = ws_mgr.is_protected(body.workspace)
+    pin_verified = False
+    if is_protected:
         if not body.pin:
             _error(
                 f"Workspace '{body.workspace}' is protected. Provide 'pin'.",
@@ -354,6 +360,7 @@ async def start_planner_session(
             )
         if not ws_mgr.verify_pin(body.pin):
             _error("Invalid PIN for protected workspace.", 403)
+        pin_verified = True
 
     # Auto-infer languages/frameworks
     try:
@@ -366,11 +373,17 @@ async def start_planner_session(
     # Create session (Issue #193: pass github_repo through so the
     # Planner's deterministic pre-fetch can resolve same-repo refs
     # like "Issue #113" in user messages).
+    # `authorized` is True only when the PIN was actually verified —
+    # for unprotected workspaces it stays False, and that's fine because
+    # the submit endpoint only consults this flag when the workspace is
+    # still protected at submit time. This preserves the TOCTOU guard
+    # for the "unprotected at start, newly protected at submit" case.
     session = create_planner_session(
         workspace=body.workspace,
         languages=stack["languages"],
         frameworks=stack["frameworks"],
         github_repo=body.github_repo,
+        authorized=pin_verified,
     )
     planner_sessions.create(session)
 
@@ -497,7 +510,13 @@ async def submit_planner_session(
             403,
         )
         return
-    if ws_mgr.is_protected(workspace):
+    # A protected workspace is fine IF the session was PIN-verified at
+    # start time (session.authorized=True). Reject only if the workspace
+    # is protected AND this session never cleared the PIN gate — which
+    # catches the real TOCTOU case (workspace was unprotected at start,
+    # newly protected at submit) without punishing users who already
+    # authorized moments ago.
+    if ws_mgr.is_protected(workspace) and not session.authorized:
         _error(
             f"Workspace '{workspace}' now requires re-authorization. "
             f"Start a new planner session with a PIN.",

--- a/dev-suite/tests/test_api.py
+++ b/dev-suite/tests/test_api.py
@@ -494,3 +494,154 @@ class TestAuth:
     def test_health_bypasses_auth(self, auth_client):
         r = auth_client.get("/health")
         assert r.status_code == 200
+
+
+# -- Planner submit re-authorization (regression for protected-workspace bug) --
+
+
+class TestPlannerSubmitReauth:
+    """Regression guard: the submit endpoint used to reject every
+    protected-workspace session with "now requires re-authorization"
+    even when the user had PIN-verified at start. Now the session
+    carries an `authorized` flag and submit only rejects when the
+    workspace became newly protected AND the session wasn't verified.
+    """
+
+    def _make_session_store_with(self, session):
+        """Install a single session into the planner session store."""
+        from src.agents.planner import planner_sessions
+        planner_sessions._sessions[session.session_id] = session
+        return session.session_id
+
+    def test_submit_allowed_when_session_authorized_and_protected(
+        self, client, tmp_path,
+    ):
+        """Protected workspace + session.authorized=True → submit OK
+        (this is the exact flow the bug report hit: the user just
+        PIN-verified, started the session, chatted with the Planner,
+        and clicked Submit).
+        """
+        from unittest.mock import MagicMock
+
+        from src.agents.planner import create_planner_session
+        from src.api import main as main_mod
+
+        # Minimal task spec that passes the required-fields checklist.
+        ws = str(tmp_path)
+        session = create_planner_session(
+            workspace=ws,
+            languages=["Python"],
+            authorized=True,
+        )
+        session.task_spec.objective = "Fix the bug"
+        # Re-build the checklist so required_satisfied is True.
+        from src.agents.planner import build_checklist
+        session.checklist = build_checklist(session.task_spec)
+        sid = self._make_session_store_with(session)
+
+        ws_mgr = MagicMock()
+        ws_mgr.is_allowed.return_value = True
+        ws_mgr.is_protected.return_value = True  # still protected
+        main_mod.state_manager._workspace_manager = ws_mgr
+
+        # Stub task_runner.submit and create_task so the submit doesn't
+        # actually kick off a workflow.
+        main_mod.state_manager.create_task = AsyncMock(return_value="task-xyz")
+        from src.api.runner import task_runner
+        task_runner.submit = MagicMock()
+
+        r = client.post(f"/tasks/plan/{sid}/submit")
+        assert r.status_code == 200, r.text
+        # No "re-authorization" error — the authorized flag saved us.
+        assert "re-authorization" not in r.text.lower()
+
+    def test_submit_rejected_when_newly_protected_and_not_authorized(
+        self, client, tmp_path,
+    ):
+        """Protected workspace + session.authorized=False → reject.
+        This is the real TOCTOU case: workspace was unprotected when
+        the user started the session, admin protected it mid-flight,
+        the user never entered a PIN — we must reject.
+        """
+        from unittest.mock import MagicMock
+
+        from src.agents.planner import build_checklist, create_planner_session
+        from src.api import main as main_mod
+
+        ws = str(tmp_path)
+        session = create_planner_session(
+            workspace=ws,
+            languages=["Python"],
+            authorized=False,  # never PIN-verified
+        )
+        session.task_spec.objective = "Fix the bug"
+        session.checklist = build_checklist(session.task_spec)
+        sid = self._make_session_store_with(session)
+
+        ws_mgr = MagicMock()
+        ws_mgr.is_allowed.return_value = True
+        ws_mgr.is_protected.return_value = True
+        main_mod.state_manager._workspace_manager = ws_mgr
+
+        r = client.post(f"/tasks/plan/{sid}/submit")
+        assert r.status_code == 403
+        assert "re-authorization" in r.json()["detail"].lower()
+
+    def test_submit_allowed_when_workspace_unprotected(
+        self, client, tmp_path,
+    ):
+        """Unprotected workspace → submit OK regardless of authorized flag."""
+        from unittest.mock import MagicMock
+
+        from src.agents.planner import build_checklist, create_planner_session
+        from src.api import main as main_mod
+
+        ws = str(tmp_path)
+        session = create_planner_session(
+            workspace=ws,
+            languages=["Python"],
+            authorized=False,  # never protected, never needed to verify
+        )
+        session.task_spec.objective = "Fix the bug"
+        session.checklist = build_checklist(session.task_spec)
+        sid = self._make_session_store_with(session)
+
+        ws_mgr = MagicMock()
+        ws_mgr.is_allowed.return_value = True
+        ws_mgr.is_protected.return_value = False
+        main_mod.state_manager._workspace_manager = ws_mgr
+        main_mod.state_manager.create_task = AsyncMock(return_value="task-xyz")
+        from src.api.runner import task_runner
+        task_runner.submit = MagicMock()
+
+        r = client.post(f"/tasks/plan/{sid}/submit")
+        assert r.status_code == 200, r.text
+
+    def test_submit_rejected_when_workspace_no_longer_allowed(
+        self, client, tmp_path,
+    ):
+        """Workspace removed from allowed list between start and submit
+        must still reject regardless of authorized flag.
+        """
+        from unittest.mock import MagicMock
+
+        from src.agents.planner import build_checklist, create_planner_session
+        from src.api import main as main_mod
+
+        ws = str(tmp_path)
+        session = create_planner_session(
+            workspace=ws,
+            languages=["Python"],
+            authorized=True,
+        )
+        session.task_spec.objective = "Fix the bug"
+        session.checklist = build_checklist(session.task_spec)
+        sid = self._make_session_store_with(session)
+
+        ws_mgr = MagicMock()
+        ws_mgr.is_allowed.return_value = False  # newly disallowed
+        main_mod.state_manager._workspace_manager = ws_mgr
+
+        r = client.post(f"/tasks/plan/{sid}/submit")
+        assert r.status_code == 403
+        assert "no longer in the allowed" in r.json()["detail"].lower()

--- a/dev-suite/tests/test_planner.py
+++ b/dev-suite/tests/test_planner.py
@@ -1124,6 +1124,48 @@ class TestPlannerGithubRepoPlumbing:
 
 
 # =========================================================================
+# Session authorization flag (submit-time re-auth regression)
+# =========================================================================
+
+
+class TestPlannerSessionAuthorization:
+    """Regression guard for the submit-time re-auth bug where every
+    submission to a protected workspace forced a new session + PIN,
+    even when the user had just PIN-verified at session start.
+    """
+
+    def test_authorized_defaults_to_false(self, tmp_path):
+        """Unauthorized by default — callers must opt in explicitly."""
+        from src.agents.planner import create_planner_session
+
+        session = create_planner_session(workspace=str(tmp_path))
+        assert session.authorized is False
+
+    def test_create_session_with_authorized_true(self, tmp_path):
+        """API layer stamps authorized=True after PIN verification."""
+        from src.agents.planner import create_planner_session
+
+        session = create_planner_session(
+            workspace=str(tmp_path),
+            authorized=True,
+        )
+        assert session.authorized is True
+
+    def test_create_session_with_authorized_false_is_explicit(self, tmp_path):
+        """Unprotected workspaces pass authorized=False — the submit
+        endpoint only consults the flag when the workspace is still
+        protected, so this is fine.
+        """
+        from src.agents.planner import create_planner_session
+
+        session = create_planner_session(
+            workspace=str(tmp_path),
+            authorized=False,
+        )
+        assert session.authorized is False
+
+
+# =========================================================================
 # Anti-hallucination system prompt (Issue #193 AC #3d)
 # =========================================================================
 


### PR DESCRIPTION
## Summary

Post-#202 smoke: the Planner ran perfectly on *"Review and implement the fix for GitHub Issue #113"* and produced a grounded spec citing the real `dashboard/src/lib/components/BottomPanel.svelte` path, real AC text, real framework stack — no hallucination. 🎉

But clicking **Submit** returned:

> *Workspace 'C:\Users\maber\Documents\GitHub\agent-dev' now requires re-authorization. Start a new planner session with a PIN.*

...even though the user had just PIN-verified moments earlier at session start. The submit endpoint's TOCTOU guard at [api/main.py:500](dev-suite/src/api/main.py) fired unconditionally for any protected workspace — the session had no memory that its PIN had been verified, so "still protected" was treated the same as "newly protected."

## Fix

Give the session an explicit authorization flag.

- `PlannerSession.authorized: bool = False` — new field. [planner.py:200-209](dev-suite/src/agents/planner.py)
- `create_planner_session(..., authorized: bool = False)` — new kwarg.
- `POST /tasks/plan` stamps `authorized=True` **only** when the workspace was protected AND the PIN was successfully verified. Unprotected workspaces leave it False — fine because the submit check only consults the flag when the workspace is still protected at submit time.
- `POST /tasks/plan/{id}/submit` rejects only when the workspace is protected AND the session was never authorized. The real TOCTOU case (unprotected at start → newly protected at submit → PIN never entered) still gets caught; normal flows go through.

## Test plan

- [x] `uv run ruff check src/ tests/` — clean
- [x] 7 new tests pass:
  - `TestPlannerSessionAuthorization` (3) — flag defaults to False, opt-in True, explicit False round-trip
  - `TestPlannerSubmitReauth` (4) — the four meaningful auth-state combinations:
    - protected + authorized → submit OK
    - protected + unauthorized → reject with "re-authorization" message
    - unprotected (regardless of flag) → submit OK
    - workspace no longer allowed (TOCTOU) → reject regardless of flag
- [x] `uv run pytest tests/test_planner.py tests/test_api.py tests/test_tool_binding.py tests/test_architect_two_phase.py tests/test_github_fetch.py tests/test_mcp_tools.py` — 354/354 pass
- [ ] Post-merge smoke: after PIN-verifying a protected workspace and running the Planner through to Submit, the task should reach the Architect instead of bouncing back to the PIN screen.

Follow-up to #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)