### PR TITLE
feat(fix-113-resize-pointer): Fix terminal resize cap and migrate to pointer events (issue #113)

### DIFF
--- a/dashboard/src/lib/components/BottomPanel.svelte
+++ b/dashboard/src/lib/components/BottomPanel.svelte
@@ -10,7 +10,7 @@
 	Issue #106: Pass workspace to tasksStore.create()
 -->
 <script lang="ts">
-	import { onMount } from 'svelte';
+	import { onMount, onDestroy } from 'svelte';
 	import { tasksStore } from '$lib/stores/tasks.svelte.js';
 	import { workspacesStore } from '$lib/stores/workspaces.svelte.js';
 
@@ -22,8 +22,10 @@
 	let { height, onResize }: Props = $props();
 
 	let isDragging = $state(false);
-	let startY = $state(0);
-	let startH = $state(0);
+	let startY = 0;
+	let startH = 0;
+	let capturedPointerId: number | null = null;
+	let capturedTarget: HTMLElement | null = null;
 
 	const tabs = ['TERMINAL', 'PROBLEMS', 'OUTPUT'];
 	let activeTab = $state('TERMINAL');
@@ -94,21 +96,52 @@
 		}
 	});
 
-	function handleMouseDown(e: MouseEvent) {
+	function handlePointerDown(e: PointerEvent) {
+		e.preventDefault();
 		isDragging = true;
 		startY = e.clientY;
 		startH = height;
+		capturedPointerId = e.pointerId;
+		capturedTarget = e.currentTarget as HTMLElement;
+		capturedTarget.setPointerCapture(e.pointerId);
+		document.body.style.userSelect = 'none';
+		window.addEventListener('pointermove', handlePointerMove);
+		window.addEventListener('pointerup', handlePointerUp);
 	}
 
-	function handleMouseMove(e: MouseEvent) {
+	function handlePointerMove(e: PointerEvent) {
 		if (!isDragging) return;
-		const newHeight = Math.max(60, Math.min(400, startH + (startY - e.clientY)));
+		const newHeight = Math.max(60, Math.min(window.innerHeight * 0.8, startH + (startY - e.clientY)));
 		onResize(newHeight);
 	}
 
-	function handleMouseUp() {
+	function handlePointerUp(e: PointerEvent) {
 		isDragging = false;
+		document.body.style.userSelect = '';
+		window.removeEventListener('pointermove', handlePointerMove);
+		window.removeEventListener('pointerup', handlePointerUp);
+		if (capturedTarget && capturedPointerId !== null) {
+			try { capturedTarget.releasePointerCapture(capturedPointerId); } catch { /* already released */ }
+		}
+		capturedPointerId = null;
+		capturedTarget = null;
 	}
+
+	function cleanupDragListeners() {
+		window.removeEventListener('pointermove', handlePointerMove);
+		window.removeEventListener('pointerup', handlePointerUp);
+		if (isDragging) {
+			isDragging = false;
+			document.body.style.userSelect = '';
+		}
+		if (capturedTarget && capturedPointerId !== null) {
+			try { capturedTarget.releasePointerCapture(capturedPointerId); } catch { /* already released */ }
+		}
+		capturedPointerId = null;
+		capturedTarget = null;
+	}
+
+	onDestroy(cleanupDragListeners);
 
 	async function handleCmd() {
 		const text = input.trim();
@@ -153,8 +186,6 @@
 	}
 </script>
 
-<svelte:window onmousemove={handleMouseMove} onmouseup={handleMouseUp} />
-
 <div
 	class="flex shrink-0 flex-col border-t"
 	style="height: {height}px; background: var(--color-bg-activity); border-color: var(--color-border);"
@@ -162,8 +193,8 @@
 	<!-- svelte-ignore a11y_no_static_element_interactions -->
 	<div
 		class="flex h-1 shrink-0 cursor-ns-resize items-center justify-center"
-		style="background: {isDragging ? 'var(--color-accent-cyan)' : 'transparent'};"
-		onmousedown={handleMouseDown}
+		style="background: {isDragging ? 'var(--color-accent-cyan)' : 'transparent'}; touch-action: none;"
+		onpointerdown={handlePointerDown}
 	>
 		<div class="h-0.5 w-10 rounded-sm" style="background: var(--color-bg-surface);"></div>
 	</div>


### PR DESCRIPTION
## Task: `fix-113-resize-pointer`

Open dashboard/src/lib/components/BottomPanel.svelte and apply the following targeted changes to the drag-to-resize logic. Do NOT rewrite the entire file — use search/replace patches.

### Step 1: Replace the svelte:window directive with onDestroy cleanup

Search for the EXACT line:
```
<svelte:window onmousemove={handleMouseMove} onmouseup={handleMouseUp} />
```
Replace it with NOTHING (delete the entire line). We will attach/detach pointer listeners dynamically instead of using svelte:window.

### Step 2: Add onDestroy import

Search for the EXACT line:
```
import { onMount } from 'svelte';
```
Replace with:
```
import { onMount, onDestroy } from 'svelte';
```

### Step 3: Replace the drag state variables and handlers

Search for the EXACT block:
```
	let isDragging = $state(false);
	let startY = $state(0);
	let startH = $state(0);
```
Replace with:
```
	let isDragging = $state(false);
	let startY = 0;
	let startH = 0;
	let capturedPointerId: number | null = null;
	let capturedTarget: HTMLElement | null = null;
```

### Step 4: Replace handleMouseDown with handlePointerDown

Search for the EXACT block:
```
	function handleMouseDown(e: MouseEvent) {
		isDragging = true;
		startY = e.clientY;
		startH = height;
	}
```
Replace with:
```
	function handlePointerDown(e: PointerEvent) {
		e.preventDefault();
		isDragging = true;
		startY = e.clientY;
		startH = height;
		capturedPointerId = e.pointerId;
		capturedTarget = e.currentTarget as HTMLElement;
		capturedTarget.setPointerCapture(e.pointerId);
		document.body.style.userSelect = 'none';
		window.addEventListener('pointermove', handlePointerMove);
		window.addEventListener('pointerup', handlePointerUp);
	}
```

### Step 5: Replace handleMouseMove with handlePointerMove

Search for the EXACT block:
```
	function handleMouseMove(e: MouseEvent) {
		if (!isDragging) return;
		const newHeight = Math.max(60, Math.min(400, startH + (startY - e.clientY)));
		onResize(newHeight);
	}
```
Replace with:
```
	function handlePointerMove(e: PointerEvent) {
		if (!isDragging) return;
		const newHeight = Math.max(60, Math.min(window.innerHeight * 0.8, startH + (startY - e.clientY)));
		onResize(newHeight);
	}
```

### Step 6: Replace handleMouseUp with handlePointerUp

Search for the EXACT block:
```
	function handleMouseUp() {
		isDragging = false;
	}
```
Replace with:
```
	function handlePointerUp(e: PointerEvent) {
		isDragging = false;
		document.body.style.userSelect = '';
		window.removeEventListener('pointermove', handlePointerMove);
		window.removeEventListener('pointerup', handlePointerUp);
		if (capturedTarget && capturedPointerId !== null) {
			try { capturedTarget.releasePointerCapture(capturedPointerId); } catch { /* already released */ }
		}
		capturedPointerId = null;
		capturedTarget = null;
	}

	function cleanupDragListeners() {
		window.removeEventListener('pointermove', handlePointerMove);
		window.removeEventListener('pointerup', handlePointerUp);
		if (isDragging) {
			isDragging = false;
			document.body.style.userSelect = '';
		}
		if (capturedTarget && capturedPointerId !== null) {
			try { capturedTarget.releasePointerCapture(capturedPointerId); } catch { /* already released */ }
		}
		capturedPointerId = null;
		capturedTarget = null;
	}

	onDestroy(cleanupDragListeners);
```

### Step 7: Update the resize handle element to use pointerdown and touch-action

Search for the EXACT block:
```
	<div
		class="flex h-1 shrink-0 cursor-ns-resize items-center justify-center"
		style="background: {isDragging ? 'var(--color-accent-cyan)' : 'transparent'};"
		onmousedown={handleMouseDown}
	>
```
Replace with:
```
	<div
		class="flex h-1 shrink-0 cursor-ns-resize items-center justify-center"
		style="background: {isDragging ? 'var(--color-accent-cyan)' : 'transparent'}; touch-action: none;"
		onpointerdown={handlePointerDown}
	>
```

### Acceptance Criteria
- [x] Terminal panel resizes smoothly up to ~80% viewport height (Math.min(window.innerHeight * 0.8, ...) is used instead of Math.min(400, ...))
- [x] No cursor/panel disconnect during drag — pointer capture is set on pointerdown and released on pointerup
- [x] Minimum height of 60px is preserved in the Math.max(60, ...) call
- [x] Pointer events are used: onpointerdown on the handle, pointermove/pointerup on window
- [x] Listeners are cleaned up on pointerup — both pointermove and pointerup removed from window
- [x] Listeners are cleaned up on component destroy via onDestroy(cleanupDragListeners)
- [x] Text selection is prevented during drag (document.body.style.userSelect = 'none' on start, restored on end)
- [x] touch-action: none is set on the resize handle element
- [x] The <svelte:window onmousemove={handleMouseMove} onmouseup={handleMouseUp} /> directive is removed
- [x] All existing functionality (SSE log streaming, command input, tab switching, auto-scroll) is preserved unchanged
- [x] File passes svelte-check with no new type errors

### Files Changed
- `dashboard/src/lib/components/BottomPanel.svelte`

---
_Opened automatically by the agent orchestrator._